### PR TITLE
Add a desktop file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = EosAppStore images
+SUBDIRS = data EosAppStore images
 
 bin_SCRIPTS = eos-app-store
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,12 +9,15 @@ AM_INIT_AUTOMAKE([1.9 no-dist-gzip dist-xz foreign])
 
 AM_PATH_PYTHON_VERSION(2.7, 2.7.0, 2.6, 2.6.0, 2.5, 2.5.0, 2.4, 2.4.0)
 
+IT_PROG_INTLTOOL(0.40.0)
+
 PKG_CHECK_MODULES(EOS_APP_STORE,
                   gio-2.0
                   gtk+-3.0)
 
 AC_CONFIG_FILES([
         Makefile
+        data/Makefile
         images/Makefile
         EosAppStore/Makefile
         EosAppStore/add_shortcuts_module/Makefile
@@ -29,6 +32,7 @@ AC_CONFIG_FILES([
         EosAppStore/removal_module/Makefile
         EosAppStore/shortcut/Makefile
         EosAppStore/util/Makefile
+        po/Makefile.in
         ])
 
 AC_OUTPUT

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,0 +1,12 @@
+desktopdir = $(datadir)/applications
+desktop_DATA = eos-app-store.desktop
+
+@INTLTOOL_DESKTOP_RULE@
+
+EXTRA_DIST = \
+	eos-app-store.desktop.in \
+	$(NULL)
+
+CLEANFILES = \
+	$(desktop_DATA) \
+	$(NULL)

--- a/data/eos-app-store.desktop.in
+++ b/data/eos-app-store.desktop.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+_Name=Add
+_Comment=Add applications to EOS
+Exec=eos-app-store
+Type=Application
+Icon=eos-app-store


### PR DESCRIPTION
This will reduce the custom code the Shell needs to carry in order to
support the app store.

[endlessm/eos-shell#198]
