### PR TITLE
Do not show app-store in app-store

### DIFF
--- a/EosAppStore/application_store/installed_applications_model.py
+++ b/EosAppStore/application_store/installed_applications_model.py
@@ -23,6 +23,8 @@ class InstalledApplicationsModel():
         value = self._settings.get_value(self.ICON_GRID_LAYOUT_SETTING)
         layout = value.unpack()
         self._installed_applications = [item for sublist in layout.values() for item in sublist]
+        # Include eos-app-store as an installed application
+        self._installed_applications.append("eos-app-store.desktop")
 
     def installed_applications(self):
         self._load_data()


### PR DESCRIPTION
Do not list eos-app-store as an installable application in the app store
itself.

Actually, it can be considered as already installed, so include it in
the list of installed applications.

[endlessm/eos-shell#403]
