### PR TITLE
Avoid duplicates while filling desktop

### DIFF
--- a/eos-fill-desktop.in
+++ b/eos-fill-desktop.in
@@ -15,7 +15,7 @@ ICON_GRID_LAYOUT_SETTING = 'icon-grid-layout'
 settings = Gio.Settings.new(schema_id = EOS_SHELL_SCHEMA)
 value = settings.get_value(ICON_GRID_LAYOUT_SETTING)
 layout = value.unpack()
-entries = layout['']
+entries = reduce(lambda x, y: x + y, layout.values())
 
 files_model = DesktopFileUtilities()
 
@@ -23,13 +23,14 @@ for desktop_filename in sorted(files_model.get_desktop_files(path_util.DEFAULT_A
     if desktop_filename.startswith(path_util.EOS_APP_PREFIX):
         if not desktop_filename.startswith('eos-app-store'):
             if not desktop_filename in entries:
+                layout[''].append(desktop_filename)
                 entries.append(desktop_filename)
 
 for desktop_filename in sorted(files_model.get_desktop_files(path_util.DEFAULT_SITES_DIRECTORY)):
     if desktop_filename.startswith(path_util.EOS_LINK_PREFIX):
         if not desktop_filename in entries:
+            layout[''].append(desktop_filename)
             entries.append(desktop_filename)
 
-layout[''] = entries
 settings.set_value(ICON_GRID_LAYOUT_SETTING, GLib.Variant('a{sas}', layout))
 settings.sync()


### PR DESCRIPTION
The system does not support any duplicate items on the desktop
or in the desktop folders.

In the eos-fill-desktop script, we intended to not create copies
of any application or link that is already installed.
However, the existing logic did not prevent adding an item to the
desktop that exists in a folder.

[endlessm/eos-shell#806]
