### PR TITLE
Set X-Endless-Splash-Screen to false (endlessm/eos-shell#699)

### DIFF
--- a/data/eos-app-store.desktop.in
+++ b/data/eos-app-store.desktop.in
@@ -4,3 +4,4 @@ _Comment=Add applications to EOS
 Exec=eos-app-store
 Type=Application
 Icon=eos-app-store
+X-Endless-Splash-Screen=false


### PR DESCRIPTION
Set `X-Endless-Splash-Screen` to false in the .desktop file, to avoid showing the splash screen.

This requires endlessm/eos-shell#699 to work.
