### PR TITLE
Move command parsing to primary instance

### DIFF
--- a/EosAppStore/appStore.js
+++ b/EosAppStore/appStore.js
@@ -41,7 +41,8 @@ const AppStore = new Lang.Class({
         GLib.set_prgname('eos-app-store');
         GLib.set_application_name(_("Application Store"));
 
-        this.parent({ application_id: APP_STORE_NAME, });
+        this.parent({ application_id: APP_STORE_NAME, 
+                      flags: Gio.ApplicationFlags.HANDLES_COMMAND_LINE });
 
         this._initialPage = initialPage;
         this._storeModel = new StoreModel.StoreModel();
@@ -73,6 +74,41 @@ const AppStore = new Lang.Class({
 
     vfunc_activate: function() {
         this._mainWindow.toggle(0);
+    },
+
+    vfunc_command_line: function(cmdline) {
+        let initialPage = StoreModel.StorePage.APPS;
+        let args = cmdline.get_arguments();
+        for (let i = 0; i < args.length; i++) {
+            let arg = args[i];
+
+            if (arg == '--apps' || arg == '-a') {
+                initialPage = StoreModel.StorePage.APPS;
+                args.splice(i, 1);
+                break;
+            }
+
+            if (arg == '--web-links' || arg == '-w') {
+                initialPage = StoreModel.StorePage.WEB;
+                args.splice(i, 1);
+                break;
+            }
+
+            if (arg == '--folders' || arg == '-f') {
+                initialPage = StoreModel.StorePage.FOLDERS;
+                args.splice(i, 1);
+                break;
+            }
+
+            log("Unrecognized argument '" + arg + "'\n" +
+                "Usage: eos-app-store [--apps|--folders|--web-links]");
+            return -1;
+        }
+
+        this._storeModel.changePage(initialPage);
+
+        this.activate();
+        return 0;
     },
 
     get mainWindow() {

--- a/EosAppStore/main.js
+++ b/EosAppStore/main.js
@@ -9,34 +9,6 @@ function start() {
     window.C_ = Gettext.pgettext;
     window.ngettext = Gettext.ngettext;
 
-    let initialPage = StoreModel.StorePage.APPS;
-    let args = ARGV;
-    for (let i = 0; i < args.length; i++) {
-        let arg = args[i];
-
-        if (arg == '--apps' || arg == '-a') {
-            initialPage = StoreModel.StorePage.APPS;
-            ARGV.splice(i, 1);
-            break;
-        }
-
-        if (arg == '--web-links' || arg == '-w') {
-            initialPage = StoreModel.StorePage.WEB;
-            ARGV.splice(i, 1);
-            break;
-        }
-
-        if (arg == '--folders' || arg == '-f') {
-            initialPage = StoreModel.StorePage.FOLDERS;
-            ARGV.splice(i, 1);
-            break;
-        }
-
-        log("Unrecognized argument '" + arg + "'\n" +
-            "Usage: eos-app-store [--apps|--folders|--web-links]");
-        return -1;
-    }
-
-    let app = new AppStore.AppStore(initialPage);
+    let app = new AppStore.AppStore(StoreModel.StorePage.APPS);
     return app.run(ARGV);
 }


### PR DESCRIPTION
Take advantage of the GTK application infrastructure
to pass command line parameters to the primary instance.
Thus, if the app store is already running, the commands
are properly applied to the running instance.

[endlessm/eos-shell#925]
