### PR TITLE
Ensure to refresh pages when the model changes

### DIFF
--- a/EosAppStore/appListModel.js
+++ b/EosAppStore/appListModel.js
@@ -124,10 +124,17 @@ const WeblinkList = new Lang.Class({
     Name: 'WeblinkList',
     Extends: BaseList,
 
+    _init: function() {
+        this._weblinks = [];
+        this.parent();
+    },
+
     _onModelChanged: function(model, items) {
         let weblinks = items.filter(function(item) {
             return item.indexOf(EOS_LINK_PREFIX) == 0;
         });
+
+        this._weblinks = weblinks;
         this.emit('changed', weblinks);
     },
 
@@ -155,6 +162,10 @@ const WeblinkList = new Lang.Class({
         }
 
         return defaultExec;
+    },
+
+    getWeblinks: function() {
+        return this._weblinks;
     },
 
     getWeblinkUrl: function(id) {

--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -270,14 +270,12 @@ const AppStoreWindow = new Lang.Class({
             case StoreModel.StorePage.APPS:
                 title.set_text(_("INSTALL APPLICATIONS"));
                 desc.set_text(_("A list of many free applications you can install and update"));
-                this._pages.apps.update();
                 page = this._pages.apps;
                 break;
 
             case StoreModel.StorePage.WEB:
                 title.set_text(_("INSTALL SITES"));
                 desc.set_text(_("A list of many sites you can add"));
-                this._pages.weblinks.update();
                 page = this._pages.weblinks;
                 break;
 

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -344,7 +344,6 @@ const WeblinkFrame = new Lang.Class({
         }
 
         this._weblinkListModel = new AppListModel.WeblinkList();
-        this._weblinkListModel.connect('changed', Lang.bind(this, this._onListModelChange));
 
         this._newSiteBox = new NewSiteBox(this._weblinkListModel);
         this._newSiteFrame.add(this._newSiteBox);
@@ -356,16 +355,22 @@ const WeblinkFrame = new Lang.Class({
         }
 
         this._viewport.show_all();
+
+        this._weblinkListModel.connect('changed', Lang.bind(this, this._onListModelChange));
+        this._onListModelChange();
     },
 
-    _onListModelChange: function(model, weblinks) {
+    _onListModelChange: function() {
         for (let i = 0; i < this._columns; i++) {
             this._listBoxes[i].foreach(function(child) { child.destroy(); });
         }
 
+        let model = this._weblinkListModel;
+        let weblinks = model.getWeblinks();
         let index = 0;
+
         weblinks.forEach(Lang.bind(this, function(item) {
-            let row = new WeblinkListBoxRow(this._weblinkListModel, item);
+            let row = new WeblinkListBoxRow(model, item);
             row.weblinkName = model.getName(item);
             row.weblinkDescription = model.getComment(item);
             row.weblinkUrl = model.getWeblinkUrl(item);
@@ -375,10 +380,6 @@ const WeblinkFrame = new Lang.Class({
             this._listBoxes[(index++)%this._columns].add(row);
             row.show();
         }));
-    },
-
-    update: function() {
-        this._weblinkListModel.update();
     }
 });
 Builder.bindTemplateChildren(WeblinkFrame.prototype);


### PR DESCRIPTION
We do this for both the applications and weblinks pages. As a side
consequence of this code refactor we now avoid loading the whole
weblinks model every time we switch to that page, which makes it much
faster.

[endlessm/eos-shell#1034]
