### PR TITLE
Restore the content string extraction rules and files

### DIFF
--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -300,16 +300,29 @@ extract-content-strings$(BUILD_EXEEXT): $(extract_content_strings_sources)
 
 DISTCLEANFILES += extract-content-strings$(BUILD_EXEEXT)
 
-# Need to fix make distcheck
-# For now, just comment out the content header files,
-# since we don't have translated content yet anyhow
-#content_files = $(default_app_json) $(default_links_json)
-#content_headers = $(content_files:.json=.json.h)
-#%.json.h: $(content_files) extract-content-strings$(BUILD_EXEEXT)
-#	$(AM_V_GEN) ./extract-content-strings$(BUILD_EXEEXT) $< > $@
+# this is a weird rule, but it's needed to deal with both autotools and
+# intltool brain damage, so let's explain it before it gets removed at
+# a later date, and distcheck breaks.
 #
-#noinst_DATA = $(content_headers)
-#DISTCLEANFILES += $(content_headers)
+# we need to generate the json.h header because gettext does not know how
+# to extract strings from custom JSON; we do that during build and put
+# the generated files into EXTRA_DIST, so that they get copied inside the
+# tarball during 'make dist'. intltool only checks inside $(srcdir) because
+# of reasons, so we cannot put the generated files inside $(builddir); we
+# cannot put the generated files in $(srcdir) because automake will not
+# allow that to happen during distcheck. thus, we check if a generated file
+# exists in $(srcdir) first, and build the json.h file only if it doesn't.
+# this means that you need to clean the content directory if the content
+# changes, in order for the strings to be extracted.
+content_files = $(default_app_json) $(default_links_json)
+content_headers = $(content_files:.json=.json.h)
+%.json.h: $(content_files) extract-content-strings$(BUILD_EXEEXT)
+	$(AM_V_GEN) test -f $(addprefix $(srcdir)/,$@) || ./extract-content-strings$(BUILD_EXEEXT) $< > $@
+
+all-local: $(content_headers)
+
+EXTRA_DIST += $(content_headers)
+CLEANFILES += $(content_headers)
 
 contentdir = $(datadir)/application-store
 nobase_content_DATA = \

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,9 +1,6 @@
 [encoding: UTF-8]
-# Need to fix make distcheck
-# For now, just comment out the content.json.h files,
-# since we don't have translated content yet anyhow
-#content/Default/apps/content.json.h
-#content/Default/links/content.json.h
+content/Default/apps/content.json.h
+content/Default/links/content.json.h
 data/eos-app-store.desktop.in
 [type: gettext/glade]data/eos-app-store-folder-frame.ui
 [type: gettext/glade]data/eos-app-store-list-row.ui


### PR DESCRIPTION
The distcheck failure is a combo failure of both automake and intltool.
Sadly, those are the tools that we have.

We generate the json.h files that hold the translatable strings and put
them into the dist; this way intltool can generate the message catalogue
from $(srcdir), and automake does not break trying to generate files
inside $(srcdir) during distcheck.

It's a bit of autotools Dark Magic™, but I left a comment in the source
that ought to explain it.

[endlessm/eos-shell#1176]
