### PR TITLE
Ensure applications dir exists

### DIFF
--- a/EosAppStore/appListModel.js
+++ b/EosAppStore/appListModel.js
@@ -322,6 +322,9 @@ const WeblinkList = new Lang.Class({
 
     saveIcon: function(pixbuf, format) {
         let path = GLib.build_filenamev([GLib.get_user_data_dir(), 'applications']);
+        if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
+            GLib.mkdir_with_parents(path, parseInt(750, 8));
+        }
         let [iconFilename, _] = this._getAvailableFilename(path, 'eos-link-', 'icon', '.'+ format);
         this._model.save_icon(pixbuf, format, iconFilename);
         return iconFilename;


### PR DESCRIPTION
Before saving a user-defined weblink, check that the directory where to store
the .desktop file exists (and create it if not).

[endlessm/eos-shell#1082]
