### PR TITLE
Only have the background be fully transparent

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -213,8 +213,6 @@ const AppStoreWindow = new Lang.Class({
             this.toggle(false);
             return true;
         }));
-        // bug: https://bugzilla.gnome.org/show_bug.cgi?id=703154
-        this.connect('realize', Lang.bind(this, function() { this.opacity = 0.95; }));
         this.add(this.main_box);
 
         this._loadSideImages();

--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -4,7 +4,7 @@
 @define-color app_store_selected_bg alpha(@app_store_bg, 0.80);
 
 .background {
-    background-color: @app_store_bg;
+    background-color: transparent;
     background-image: url("bg_gray_noise.png");
 }
 


### PR DESCRIPTION
Previously, we would set the opacity on the whole app store window.
Right now we just use the noise background asset as background-image for
the window, which is already semi-transparent.

[endlessm/eos-shell#1294]
