### PR TITLE
Use 'eos-link-user' as prefix for custom websites

### DIFF
--- a/EosAppStore/appListModel.js
+++ b/EosAppStore/appListModel.js
@@ -318,7 +318,7 @@ const WeblinkList = new Lang.Class({
         }
 
         let path = GLib.build_filenamev([GLib.get_user_data_dir(), 'applications']);
-        let [availablePath, availableFilename] = this._getAvailableFilename(path, 'eos-link-', filename, '.desktop');
+        let [availablePath, availableFilename] = this._getAvailableFilename(path, 'eos-link-user-', filename, '.desktop');
 
         desktop.set_string(GLib.KEY_FILE_DESKTOP_GROUP, GLib.KEY_FILE_DESKTOP_KEY_VERSION, '1.0');
         desktop.set_string(GLib.KEY_FILE_DESKTOP_GROUP, GLib.KEY_FILE_DESKTOP_KEY_TYPE, 'Application');


### PR DESCRIPTION
Instead of 'eos-link', so that we avoid clashes with stock links.

[endlessm/eos-shell#1330]
