### PR TITLE
Add dependency on eos-shell-content

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Depends: ${gir:Depends},
          gir1.2-json-1.0,
 	 gir1.2-webkit2-3.0,
 	 gjs,
-	 xdg-utils
+	 xdg-utils,
+	 eos-shell-content
 Description: Endless OS App Store installation package
  This package will install the Endless OS App Store


### PR DESCRIPTION
Now that the content is provided by a separate repo,
let's explicitly call out this dependency.

[endlessm/eos-shell#1346-debian]
