### PR TITLE
Fix suggested weblink icons in app store

### DIFF
--- a/EosAppStore/appListModel.js
+++ b/EosAppStore/appListModel.js
@@ -204,71 +204,8 @@ const WeblinkList = new Lang.Class({
         }));
 
         this._weblinks = weblinks;
-        this._cacheUrls();
 
         this.emit('changed', weblinks);
-    },
-
-    // FIXME: all this code should be removed when the CMS generates
-    // non-empty linkId for weblinks.
-    // See https://github.com/endlessm/eos-shell/issues/1074
-    _cacheUrls: function() {
-        // destroy cache
-        this._urlsToId = {};
-
-        for (let idx in this._weblinks) {
-            let link = this._weblinks[idx];
-            let url = this.getWeblinkUrl(link);
-
-            this._urlsToId[url] = link;
-        }
-    },
-
-    // FIXME: see above
-    _replaceAll: function(find, replace, str) {
-        return str.replace(new RegExp(find, 'g'), replace);
-    },
-
-    // FIXME: see above
-    _getLocalizedExec: function(args) {
-        let languages = GLib.get_language_names();
-
-        // First value is the default one
-        let defaultExec = this._replaceAll('^\'|^\"|\'$|\"$', '', args[0]);
-
-        for (let a in args.slice(1)) {
-            let arg = args[a];
-            let tokens = arg.split(':');
-            let key = tokens.shift();
-            let value = this._replaceAll('^\'|^\"|\'$|\"$', '', tokens.join(':'));
-            for (let l in languages) {
-                let language = languages[l];
-                if (language == key) {
-                    return value;
-                }
-            }
-        }
-
-        return defaultExec;
-    },
-
-    // FIXME: see above
-    getWeblinkUrl: function(id) {
-        let exec = this._model.get_app_executable(id);
-        if (exec.indexOf(EOS_LOCALIZED) == 0) {
-            exec = exec.substr(EOS_LOCALIZED.length);
-            exec = this._getLocalizedExec(exec.match(/([\w-]+|'(\\'|[^'])*')/g));
-        }
-        if (exec.indexOf(EOS_BROWSER) == 0) {
-            return exec.substr(EOS_BROWSER.length);
-        }
-
-        return exec;
-    },
-
-    // FIXME: see above
-    getWeblinkForUrl: function(url) {
-        return this._urlsToId[url];
     },
 
     getWeblinks: function() {

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -516,7 +516,7 @@ const WeblinkListBoxRow = new Lang.Class({
             this._setHoverState(false);
         }));
 
-        this._setSensitiveState(this._getStateFromUrl() != EosAppStorePrivate.AppState.INSTALLED);
+        this._setSensitiveState(this._getState() != EosAppStorePrivate.AppState.INSTALLED);
     },
 
     vfunc_state_flags_changed: function(previousFlags) {
@@ -528,32 +528,24 @@ const WeblinkListBoxRow = new Lang.Class({
 
         if (isHover) {
             this._setActiveState(true);
-            icon = this._info.get_icon();
-            if (icon) {
-                this._icon.set_from_pixbuf(icon);
+            let iconName;
+            let linkId = this._info.get_desktop_id();
+            if (linkId) {
+                iconName = 'eos-link-' + linkId;
             } else {
-                this._icon.set_from_icon_name(DEFAULT_ICON, Gtk.IconSize.DIALOG);
+                iconName = DEFAULT_ICON;
             }
+            this._icon.set_from_icon_name(iconName, Gtk.IconSize.DIALOG);
         } else {
             this._setActiveState(false);
             this._icon.clear();
         }
     },
 
-    // FIXME: this should be entirely unnecessary, as we could just use
-    // the linkId, and call getState() on WeblinkList with that ID.
-    // Unfortunately, the CMS-provided content is broken for weblinks
-    // right now, and it has a NULL linkId to all values.
-    // See https://github.com/endlessm/eos-shell/issues/1074
-    _getStateFromUrl: function() {
-        let url = this._info.get_url();
-        let id = this._model.getWeblinkForUrl(url);
-
-        if (id) {
-            return EosAppStorePrivate.AppState.INSTALLED;
-        } else {
-            return EosAppStorePrivate.AppState.UNINSTALLED;
-        }
+    _getState: function() {
+        let linkId = this._info.get_desktop_id();
+        let desktopId = 'eos-link-' + linkId;
+        return this._model.getState(desktopId);
     },
 
     _setActiveState: function(isActive) {
@@ -610,14 +602,7 @@ const WeblinkListBoxRow = new Lang.Class({
     _onStateButtonClicked: function() {
         this._parentFrame.setModelConnected(false);
 
-        let url = this._info.get_url();
-        let title = this._info.get_title();
-        let icon = this._info.get_icon_filename();
-        if (!icon) {
-            icon = DEFAULT_ICON;
-        }
-
-        let [desktopId, ] = createWeblink(url, title, icon);
+        let desktopId = 'eos-link-' + this._info.get_desktop_id();
         this._model.install(desktopId, function() {});
 
         this._showInstalledMessage();


### PR DESCRIPTION
Use the linkId to generate icon names.
Use the pre-installed desktop files rather than create new ones.
For now, we work around the fact that get_desktop_id
returns the linkId rather than the desktopId.

[endlessm/eos-shell#1074]
