### PR TITLE
Fixed mem leak from vfunc_draw in weblinksFrame

### DIFF
--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -445,7 +445,9 @@ const TwoLinesLabel = new Lang.Class({
         let layout = this.get_layout();
         layout.set_height(-2);
 
-        return this.parent(cr);
+        let ret = this.parent(cr);
+        cr.$dispose();
+        return ret;
     },
 
     set_text: function(text) {


### PR DESCRIPTION
One of the widgets in the weblinksFrame had a custom draw function.
Needed to manually dispose the cairo context.
[endlessm/eos-shell#1523]
