### PR TITLE
Add valgrind support to the launcher script

### DIFF
--- a/eos-app-store.in
+++ b/eos-app-store.in
@@ -17,4 +17,10 @@ if [ "$RUN_DEBUG" != "" ]; then
     DEBUG_COMMAND="gdb --args"
 fi
 
+if [ "$RUN_VALGRIND" != "" ]; then
+    export G_SLICE="always-malloc"
+    DEBUG_COMMAND="valgrind --tool=memcheck --leak-check=full --leak-resolution=high --num-callers=20 --log-file=eos-app-store.vgdump"
+fi
+
+echo "Running $DEBUG_COMMAND @GJS_CONSOLE@..."
 exec $DEBUG_COMMAND @GJS_CONSOLE@ -I @pkgdatadir@/js -c "const Main = imports.main; Main.start();" "$@"


### PR DESCRIPTION
We want to be able to run the app store under Valgrind in order to
check for leaks. We can do this in the same way we do for running
the launcher under GDB, through an environment variable.

[endlessm/eos-shell#1521]
