### PR TITLE
appFrame: Use the main loop to build the categories

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -315,6 +315,7 @@ const AppFrame = new Lang.Class({
             currentCategory: 0,
         };
 
+        // This is basically Mainloop.idle_add() but with a different priority
         let s = GLib.idle_source_new()
         s.set_priority(GLib.PRIORITY_DEFAULT_IDLE - 100);
         GObject.source_set_closure(s, Lang.bind(this, this._idlePopulateCategories));
@@ -362,12 +363,15 @@ const AppFrame = new Lang.Class({
                                            cell_spacing: CELL_DEFAULT_SPACING - cellMargin });
         scrollWindow.add_with_viewport(grid);
 
-        let appInfos = EosAppStorePrivate.app_load_content(category.id);
-        let availableApps = this._loadData.availableApps;
-        appInfos = appInfos.filter(function(appInfo) {
+        let appInfos = EosAppStorePrivate.app_load_content(category.id,
+                                                           Lang.bind(this, function(appInfo) {
             let id = appInfo.get_desktop_id();
-            return (availableApps.indexOf(id) != -1);
-        });
+            if (this._loadData.availableApps.indexOf(id) != -1) {
+                return true;
+            }
+
+            return false;
+        }));
 
         if (category.id == EosAppStorePrivate.AppCategory.MY_APPLICATIONS) {
             for (let i in appInfos) {

--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -3,7 +3,6 @@
 #include "config.h"
 
 #include "eos-app-utils.h"
-#include "eos-app-info.h"
 #include "eos-link-info.h"
 
 #include <locale.h>
@@ -137,13 +136,17 @@ eos_link_get_content_dir (void)
 /**
  * eos_app_load_content:
  * @category: ...
+ * @callback: (allow-none) (scope call) (closure data): ...
+ * @data: (allow-none): ...
  *
  * ...
  *
  * Return value: (transfer full) (element-type EosAppInfo): ...
  */
 GList *
-eos_app_load_content (EosAppCategory category)
+eos_app_load_content (EosAppCategory category,
+                      EosAppFilterCallback callback,
+                      gpointer data)
 {
   JsonArray *array = eos_app_parse_resource_content (APP_STORE_CONTENT_APPS,
                                                      "content");
@@ -182,6 +185,18 @@ eos_app_load_content (EosAppCategory category)
               continue;
             }
 
+        }
+
+      if (callback != NULL)
+        {
+          gboolean res;
+
+          res = callback (info, data);
+          if (!res)
+            {
+              eos_app_info_unref (info);
+              continue;
+            }
         }
 
       infos = g_list_prepend (infos, info);

--- a/EosAppStore/lib/eos-app-utils.h
+++ b/EosAppStore/lib/eos-app-utils.h
@@ -7,14 +7,20 @@
 #include <endless/endless.h>
 #include <webkit2.h>
 #include "eos-app-enums.h"
+#include "eos-app-info.h"
 
 G_BEGIN_DECLS
+
+typedef gboolean (* EosAppFilterCallback) (EosAppInfo *info,
+                                           gpointer data);
 
 char *  eos_app_get_content_dir  (void);
 
 char *  eos_link_get_content_dir (void);
 
-GList * eos_app_load_content     (EosAppCategory   category);
+GList * eos_app_load_content     (EosAppCategory   category,
+                                  EosAppFilterCallback callback,
+                                  gpointer data);
 
 GList * eos_link_load_content    (EosLinkCategory  category);
 


### PR DESCRIPTION
Instead of a tight loop over each of the categories in the applications
page, we use an idle source to load each page individually. This reduces
the time needed to get the first page in front of the user, and makes
the app store more responsive.

[endlessm/eos-shell#1823]
