### PR TITLE
appFrame: Shorten the duration of the transitions

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -16,8 +16,8 @@ const Lang = imports.lang;
 const Separator = imports.separator;
 const Signals = imports.signals;
 
-const APP_TRANSITION_MS = 500;
-const CATEGORY_TRANSITION_MS = 500;
+const APP_TRANSITION_MS = 250;
+const CATEGORY_TRANSITION_MS = 250;
 
 const CELL_DEFAULT_SIZE = 180;
 const CELL_DEFAULT_SPACING = 15;


### PR DESCRIPTION
Transitions of half a second increase the appearance of a sluggish
app store by delaying the users and preventing them to operate the
UI.

[endlessm/eos-shell#1882]
