### PR TITLE
Remove the 'Featured' category

### DIFF
--- a/EosAppStore/categories.js
+++ b/EosAppStore/categories.js
@@ -5,12 +5,6 @@ const Lang = imports.lang;
 function get_app_categories() {
     return [
         {
-            name: 'featured',
-            widget: null,
-            label: _("Featured"),
-            id: EosAppStorePrivate.AppCategory.FEATURED,
-        },
-        {
             name: 'education',
             widget: null,
             label: _("Education"),

--- a/EosAppStore/lib/eos-app-enums.c
+++ b/EosAppStore/lib/eos-app-enums.c
@@ -42,7 +42,6 @@ EOS_DEFINE_ENUM_TYPE (EosAppState, eos_app_state,
                       EOS_ENUM_VALUE (EOS_APP_STATE_UPDATABLE, updatable))
 
 EOS_DEFINE_ENUM_TYPE (EosAppCategory, eos_app_category,
-                      EOS_ENUM_VALUE (EOS_APP_CATEGORY_FEATURED, featured)
                       EOS_ENUM_VALUE (EOS_APP_CATEGORY_EDUCATION, education)
                       EOS_ENUM_VALUE (EOS_APP_CATEGORY_LEISURE, leisure)
                       EOS_ENUM_VALUE (EOS_APP_CATEGORY_UTILITIES, utilities)

--- a/EosAppStore/lib/eos-app-enums.h
+++ b/EosAppStore/lib/eos-app-enums.h
@@ -32,7 +32,6 @@ GType eos_app_state_get_type (void);
 #define EOS_TYPE_APP_CATEGORY           (eos_app_category_get_type ())
 
 typedef enum {
-  EOS_APP_CATEGORY_FEATURED,
   EOS_APP_CATEGORY_EDUCATION,
   EOS_APP_CATEGORY_LEISURE,
   EOS_APP_CATEGORY_UTILITIES,

--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -169,14 +169,6 @@ eos_app_load_content (EosAppCategory category,
         {
           /* do nothing */
         }
-      else if (category == EOS_APP_CATEGORY_FEATURED)
-        {
-          if (!eos_app_info_is_featured (info))
-            {
-              eos_app_info_unref (info);
-              continue;
-            }
-        }
       else
         {
           if (category != eos_app_info_get_category (info))


### PR DESCRIPTION
We keep the 'is featured' field in the AppInfo structure because we can
use it later, and because it's optional anyway.

[endlessm/eos-shell#1983]
