### PR TITLE
Use the right variable and attribute name

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -127,7 +127,7 @@ const AppListBoxRow = new Lang.Class({
             previewBox.connect('button-press-event', Lang.bind(this, this._onPreviewPress));
         }
 
-        if (screenshot.length() != 0) {
+        if (screenshots && screenshots.length > 0) {
             this._screenshotPreviewBox.show_all();
         }
     },


### PR DESCRIPTION
The screenshots string array is called `screenshots` and the length of
the array is stored in the `length` attribute.

[endlessm/eos-shell#2130]
