### PR TITLE
weblink: Constrain the labels sizes

### DIFF
--- a/data/eos-app-store-weblink-list-row.ui
+++ b/data/eos-app-store-weblink-list-row.ui
@@ -62,7 +62,7 @@
                 <property name="yalign">0</property>
                 <property name="label">DESCRIPTION</property>
                 <property name="ellipsize">middle</property>
-                <property name="single_line_mode">True</property>
+                <property name="max-width-chars">30</property>
                 <property name="lines">2</property>
                 <style>
                   <class name="description"/>
@@ -96,6 +96,7 @@
                         <property name="xalign">0</property>
                         <property name="ellipsize">end</property>
                         <property name="single_line_mode">True</property>
+                        <property name="max-width-chars">30</property>
                         <style>
                           <class name="url"/>
                         </style>
@@ -111,7 +112,7 @@
                 <child>
                   <object class="GtkImage" id="_urlIndicator">
                     <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
+                    <property name="hexpand">False</property>
                     <property name="xalign">0</property>
                     <property name="pixbuf">icon_blank.png</property>
                     <property name="visible">True</property>


### PR DESCRIPTION
This prevents the window from growing and forces ellipsization and
wrapping when needed.

[endlessm/eos-shell#1881]
[endlessm/eos-shell#2214]
