### PR TITLE
appStoreWindow: Do not mark as unresizable

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -76,7 +76,6 @@ const AppStoreWindow = new Lang.Class({
 
         this.initTemplate({ templateRoot: 'main-frame', bindChildren: true, connectSignals: true, });
         this.stick();
-        this.set_resizable(false);
         this.set_decorated(false);
         // do not destroy, just hide
         this.connect('delete-event', Lang.bind(this, function() {


### PR DESCRIPTION
GtkWindow will always try to ensure all the content is visible if the
window is not resizable, which means that it will ask its content to
give precedence to the natural size. The FlexyGrid widget cannot provide
a natural size without getting into covering sets algorithms, which are
not tractable in polinomial time.

For this reason, we just undecorate the window (hence we disable the
window manager from drawing a frame), and we keep it resizable. Since
we're not going to handle resizing ourselves, we have the exact same
behaviour, but we're also getting a minimum size as our default size.

[endlessm/eos-shell#2477]
