### PR TITLE
Ignore first "active-window-changed" signal

### DIFF
--- a/EosAppStore/wmInspect.js
+++ b/EosAppStore/wmInspect.js
@@ -6,6 +6,7 @@ const WMInspect = new Lang.Class({
     Name: 'WMInspect',
 
     _init: function() {
+        this._firstSignal = true;
         this._screen = Wnck.Screen.get_default();
         this._screen.connect('active-window-changed', Lang.bind(this,
             this._onActiveWindowChanged));
@@ -16,6 +17,14 @@ const WMInspect = new Lang.Class({
 
         if (!activeWindow)
             return;
+
+	// See #2518. Wnck.Screen always sends the current active window, but we
+	// are interested in when the active window changes, not what is the
+	// current active window. So let's ignore this first advertisement.
+        if (this._firstSignal) {
+	    this._firstSignal = false;
+            return;
+        }
 
         this.emit('active-window-changed', activeWindow.get_xid());
     }


### PR DESCRIPTION
Wnck.Screen always sends the current active window as the first signal,
but we are only interested when the active window changes, not what is
the current active window.

So let's ignore this first advertisement.

[endlessm/eos-shell#2518]
