### PR TITLE
Adjust width thresholds to account for overscan

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -27,10 +27,12 @@ const SIDE_COMPONENT_ROLE = 'eos-side-component';
 
 const AppStoreSizes = {
   // Note: must be listed in order of increasing screenWidth
+  // Include compensation for 5% overscan on either side,
+  // plus some additional margin
   SVGA: { screenWidth:  800, windowWidth:  800 },
-   XGA: { screenWidth: 1024, windowWidth:  800 },
-  WXGA: { screenWidth: 1366, windowWidth: 1024 },
-    HD: { screenWidth: 1920, windowWidth: 1366 },
+   XGA: { screenWidth:  900, windowWidth:  800 }, // nominally 1024
+  WXGA: { screenWidth: 1200, windowWidth: 1024 }, // nominally 1366
+    HD: { screenWidth: 1700, windowWidth: 1366 }, // nominally 1920
 };
 
 const AppStoreWindow = new Lang.Class({


### PR DESCRIPTION
We don't want the app store width to be reduced when overscan
compensation is enabled.
Include a little extra margin to account for TVs that for instance
have a width of 1360 rather than 1366.

[endlessm/eos-shell#2848]
