### PR TITLE
Fix the app_is_installed() check

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -680,10 +680,19 @@ static gboolean
 app_is_installed (EosAppListModel *model,
                   const char      *desktop_id)
 {
-  if (model->installed_apps == NULL)
-    return FALSE;
+  if (model->shell_apps != NULL &&
+      g_hash_table_contains (model->shell_apps, desktop_id))
+    return TRUE;
 
-  return g_hash_table_contains (model->installed_apps, desktop_id);
+  if (model->installed_apps != NULL &&
+      g_hash_table_contains (model->installed_apps, desktop_id))
+    return TRUE;
+
+  if (model->updatable_apps != NULL &&
+      g_hash_table_contains (model->updatable_apps, desktop_id))
+    return TRUE;
+
+  return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
We define an application to be "installed" if it satisfies any of these
prerequisites:
- it has a launcher in the shell
- it is listed in the installed apps by the AppManager
- it is listed in the updatable apps by the AppManager

[endlessm/eos-shell#2849]
