### PR TITLE
Use the personality in the app desktop filename

### DIFF
--- a/EosAppStore/appManager.js
+++ b/EosAppStore/appManager.js
@@ -5,6 +5,7 @@ const AppManagerIface = '\
 <node> \
   <interface name="com.endlessm.AppManager"> \
     <method name="Refresh"> \
+      <arg type="a{sv}" direction="in" /> \
       <arg type="b" direction="out" /> \
     </method> \
     </interface> \

--- a/EosAppStore/appStore.js
+++ b/EosAppStore/appStore.js
@@ -80,7 +80,7 @@ const AppStore = new Lang.Class({
 
         // the app manager proxy
         this._appManager = new AppManager.AppManager();
-        this._appManager.proxy.RefreshRemote();
+        this._appManager.proxy.RefreshRemote({});
 
         // the backing app list model
         this._appModel = new AppListModel.StoreModel();

--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -539,13 +539,29 @@ load_available_apps (EosAppListModel *self)
   GVariant *applications;
   GError *error = NULL;
 
+  const char * const *locales = g_get_language_names ();
+  const char *locale_name = locales[0];
+
+  char **variants = g_get_locale_variants (locale_name);
+  const char *lang_id = variants[g_strv_length (variants) - 1];
+
+  GVariantBuilder builder;
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("(a{sv})"));
+  g_variant_builder_open (&builder, G_VARIANT_TYPE ("a{sv}"));
+  g_variant_builder_add (&builder, "{sv}", "EndlessLanguage", g_variant_new_string (lang_id));
+  g_variant_builder_close (&builder);
+
+  g_strfreev (variants);
+
   applications =
     g_dbus_connection_call_sync (self->system_bus,
                                  "com.endlessm.AppManager",
                                  "/com/endlessm/AppManager",
                                  "com.endlessm.AppManager",
                                  "ListAvailable",
-                                 NULL, NULL,
+                                 g_variant_builder_end (&builder),
+                                 NULL,
                                  G_DBUS_CALL_FLAGS_NONE,
                                  -1,
                                  NULL,


### PR DESCRIPTION
If the desktop file starts with 'com.endlessm' and has the personality
as a suffix, we should use that to check if an application should be
visible in the app store.

[endlessm/eos-shell#2661]
