### PR TITLE
appStore: refresh the app manager when starting up

### DIFF
--- a/EosAppStore/Makefile-js.am
+++ b/EosAppStore/Makefile-js.am
@@ -3,6 +3,7 @@ dist_js_DATA = \
 	$(js_built_sources) \
 	appFrame.js \
 	appListModel.js \
+	appManager.js \
 	appStoreLauncher.js \
 	appStoreWindow.js \
 	appStore.js \

--- a/EosAppStore/appManager.js
+++ b/EosAppStore/appManager.js
@@ -1,0 +1,26 @@
+const Gio = imports.gi.Gio;
+const Lang = imports.lang;
+
+const AppManagerIface = '\
+<node> \
+  <interface name="com.endlessm.AppManager"> \
+    <method name="Refresh"> \
+      <arg type="b" direction="out" /> \
+    </method> \
+    </interface> \
+</node>';
+
+const APP_MANAGER_NAME = 'com.endlessm.AppManager';
+const APP_MANAGER_PATH = '/com/endlessm/AppManager';
+const APP_MANAGER_IFACE = 'com.endlessm.AppManager';
+
+const AppManagerProxy = Gio.DBusProxy.makeProxyWrapper(AppManagerIface);
+
+const AppManager = new Lang.Class({
+    Name: 'AppManager',
+
+    _init: function() {
+        this.proxy = new AppManagerProxy(Gio.DBus.system,
+            APP_MANAGER_NAME, APP_MANAGER_PATH);
+    }
+});

--- a/EosAppStore/appStore.js
+++ b/EosAppStore/appStore.js
@@ -11,6 +11,7 @@ const Signals = imports.signals;
 const _ = imports.gettext.gettext;
 
 const AppListModel = imports.appListModel;
+const AppManager = imports.appManager;
 const AppStoreWindow = imports.appStoreWindow;
 const Config = imports.config;
 const Environment = imports.environment;
@@ -76,6 +77,10 @@ const AppStore = new Lang.Class({
 
         // the app store shell proxy
         this._shellProxy = new ShellAppStore.ShellAppStore();
+
+        // the app manager proxy
+        this._appManager = new AppManager.AppManager();
+        this._appManager.proxy.RefreshRemote();
 
         // the backing app list model
         this._appModel = new AppListModel.StoreModel();


### PR DESCRIPTION
Make sure we always have the latest information available.

[endlessm/eos-shell#2877]
