### PR TITLE
appStoreWindow: don't use set_size_request()

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -193,9 +193,8 @@ const AppStoreWindow = new Lang.Class({
                          width: width,
                          height: height };
 
-
         this.move(geometry.x, geometry.y);
-        this.set_size_request(geometry.width, geometry.height);
+        this.resize(geometry.width, geometry.height);
     },
 
     _createStackPages: function() {


### PR DESCRIPTION
Or we'll fail to correctly resize the window when the monitor
configuration changes.

[endlessm/eos-shell#2942]
