### PR TITLE
app-list-model: check for unprefixed launcher desktop IDs too

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -846,6 +846,9 @@ eos_app_list_model_get_app_has_launcher (EosAppListModel *model,
   g_return_val_if_fail (EOS_IS_APP_LIST_MODEL (model), FALSE);
   g_return_val_if_fail (desktop_id != NULL, FALSE);
 
+  if (app_has_launcher (model, desktop_id))
+    return TRUE;
+
   localized_id = app_get_localized_id_for_installed_app (model, desktop_id);
   return app_has_launcher (model, localized_id);
 }


### PR DESCRIPTION
The shell icon grid always reasons in terms of unprefixed (i.e. without
leading 'eos-app-' desktop IDs), and so does the app store.
In order to avoid false negatives in the launcher checks, just look for
the unprefixed desktop ID first when searching for a launcher, falling
back to the prefixed/localized version only when that is not found.

This fixes double launchers being added for core applications installed
and on the desktop by default, such as the browser and the file manager.

[endlessm/eos-shell#2963]
