### PR TITLE
Fix include path to webkit2.h

### DIFF
--- a/EosAppStore/lib/eos-app-utils.h
+++ b/EosAppStore/lib/eos-app-utils.h
@@ -5,7 +5,7 @@
 
 #include <glib.h>
 #include <endless/endless.h>
-#include <webkit2.h>
+#include <webkit2/webkit2.h>
 #include "eos-app-enums.h"
 #include "eos-app-info.h"
 


### PR DESCRIPTION
With upgrade to webkitgtk, the standard include path
no longer includes the webkit2 subdirectory.

[endlessm/eos-shell#3201]
