### PR TITLE
Change app manager list applications from async to sync

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -456,16 +456,22 @@ load_manager_installed_apps (EosAppListModel *self)
 }
 
 static void
-on_shell_apps_loaded (GObject *source,
-                      GAsyncResult *result,
-                      gpointer user_data)
+load_shell_apps (EosAppListModel *self)
 {
-  EosAppListModel *self = user_data;
   GVariant *applications;
   GError *error = NULL;
 
-  applications = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source),
-                                                result, &error);
+  applications =
+    g_dbus_connection_call_sync (self->session_bus,
+                                 "org.gnome.Shell",
+                                 "/org/gnome/Shell",
+                                 "org.gnome.Shell.AppStore",
+                                 "ListApplications",
+                                 NULL, NULL,
+                                 G_DBUS_CALL_FLAGS_NONE,
+                                 -1,
+                                 self->load_cancellable,
+                                 &error);
 
   if (error != NULL)
     {
@@ -475,27 +481,10 @@ on_shell_apps_loaded (GObject *source,
       return;
     }
 
-
   self->shell_apps = load_shell_apps_from_gvariant (applications);
   g_variant_unref (applications);
 
   g_signal_emit (self, eos_app_list_model_signals[CHANGED], 0);
-}
-
-static void
-load_shell_apps (EosAppListModel *self)
-{
-  g_dbus_connection_call (self->session_bus,
-                          "org.gnome.Shell",
-                          "/org/gnome/Shell",
-                          "org.gnome.Shell.AppStore",
-                          "ListApplications",
-                          NULL, NULL,
-                          G_DBUS_CALL_FLAGS_NONE,
-                          -1,
-                          self->load_cancellable,
-                          on_shell_apps_loaded,
-                          self);
 }
 
 static void


### PR DESCRIPTION
This works around what appears to be a bug in the app manager,
where a sync call to ListApplications fails if there is an
outstanding async call to ListInstalled in progress.

If ListApplications really is desired to be async,
this commit can be reverted once the underyling issue
in the app manager is resolved.

[endlessm/eos-shell#3191]
