### PR TITLE
appFrame: Make removal confirmation dialog modal

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -317,7 +317,7 @@ const AppListBoxRow = new Lang.Class({
     _onRemoveButtonClicked: function() {
         let app = Gio.Application.get_default();
 
-        let dialog = new Gtk.MessageDialog({ );
+        let dialog = new Gtk.MessageDialog();
         dialog.set_transient_for(app.mainWindow);
         dialog.modal = true;
         dialog.destroy_with_parent = true;


### PR DESCRIPTION
The user may dismiss the app store window, and given the fact that the
app store is an undecorated overlay, the interaction with dialogs are
weird in the window manager stack

Since this is a proper confirmation request, we can use a modal dialog
to prevent the user from interacting with the app store.

[endlessm/eos-shell#3374]
