### PR TITLE
Close App Store on App Install

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -251,6 +251,11 @@ const AppListBoxRow = new Lang.Class({
                     }
                     else {
                         this._maybeNotify(_("'%s' was installed successfully").format(this.appTitle));
+
+                        let appWindow = Gio.Application.get_default().mainWindow;
+                        if (appWindow && appWindow.is_visible()) {
+                            appWindow.hide();
+                        }
                     }
                 }));
                 break;
@@ -280,6 +285,11 @@ const AppListBoxRow = new Lang.Class({
                     }
 
                     this._installedMessage.show();
+
+                    let appWindow = Gio.Application.get_default().mainWindow;
+                    if (appWindow && appWindow.is_visible()) {
+                        appWindow.hide();
+                    }
 
                     Mainloop.timeout_add_seconds(3, Lang.bind(this, function() {
                         this._installedMessage.hide();


### PR DESCRIPTION
When a new app is installed or an already installed app is added
to the desktop, the App Store closes.

[endlessm/eos-shell#3398]
