### PR TITLE
Prevent app details page width resize

### DIFF
--- a/data/eos-app-store-list-row.ui
+++ b/data/eos-app-store-list-row.ui
@@ -274,7 +274,6 @@
                     <property name="height_request">38</property>
                     <property name="halign">start</property>
                     <property name="margin-bottom">40</property>
-                    <property name="margin-end">40</property>
                     <style>
                       <class name="state-button"/>
                       <class name="remove"/>
@@ -284,7 +283,7 @@
                       <object class="GtkBox" id="box2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">12</property>
+                        <property name="spacing">8</property>
                         <child>
                           <object class="GtkFrame" id="_removeButtonImage">
                             <property name="visible">True</property>


### PR DESCRIPTION
Don't enforce a 40 pixel margin on the right of the delete button,
and reduce the spacing inside the button.

[endlessm/eos-shell#3482]
