### PR TITLE
webLinkRow: Fix wrong font size and top margin

### DIFF
--- a/data/eos-app-store-weblink-list-row.ui
+++ b/data/eos-app-store-weblink-list-row.ui
@@ -31,7 +31,7 @@
             <property name="orientation">vertical</property>
             <property name="margin_left">15</property>
             <property name="margin_right">15</property>
-            <property name="margin_top">15</property>
+            <property name="margin_top">17</property>
             <property name="margin_bottom">8</property>
             <property name="vexpand">True</property>
             <property name="hexpand">False</property>

--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -511,7 +511,7 @@
 }
 
 .weblink-listbox .list-row .title {
-    font-size: 15px;
+    font-size: 12px;
     font-weight: bold;
     color: white;
 }
@@ -522,7 +522,7 @@
 
 .weblink-listbox .list-row .description {
     color: #b4b4b4;
-    font-size: 13px;
+    font-size: 10px;
 }
 
 .weblink-listbox .list-row .row-highlight .description {


### PR DESCRIPTION
Font size was too big for title and description, and top margin inside
the link box was too small.

[endlessm/eos-shell#3234]
