### PR TITLE
Reduce the duration of the page transition

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -21,7 +21,7 @@ const WMInspect = imports.wmInspect;
 
 const ANIMATION_TIME = (500 * 1000); // half a second
 
-const PAGE_TRANSITION_MS = 500;
+const PAGE_TRANSITION_MS = 250;
 
 const SIDE_COMPONENT_ROLE = 'eos-side-component';
 


### PR DESCRIPTION
500 msecs seems a bit too long, and makes the app store feel slow.

[endlessm/eos-shell#3356]
