### PR TITLE
appStoreWindow: Remove the "check" icon next to the title for installed apps

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -82,7 +82,6 @@ const AppStoreWindow = new Lang.Class({
         'header-bar-box',
         'header-bar-title-label',
         'header-bar-subtitle-label',
-        'header-bar-installed-image',
         'header-icon',
         'close-button',
         'back-button',
@@ -422,7 +421,6 @@ const AppStoreWindow = new Lang.Class({
         this.titleText = null;
         this.subtitleText = null;
         this.headerIcon = null;
-        this.headerInstalledVisible = false;
         this.backButtonVisible = false;
     },
 
@@ -452,14 +450,6 @@ const AppStoreWindow = new Lang.Class({
         }
         else {
             this.header_icon.hide();
-        }
-    },
-
-    set headerInstalledVisible(isVisible) {
-        if (isVisible) {
-            this.header_bar_installed_image.show();
-        } else {
-            this.header_bar_installed_image.hide();
         }
     },
 

--- a/data/eos-app-store-main-window.ui
+++ b/data/eos-app-store-main-window.ui
@@ -361,21 +361,6 @@
                                             <property name="position">0</property>
                                           </packing>
                                         </child>
-                                        <child>
-                                          <object class="GtkImage" id="header-bar-installed-image">
-                                            <property name="can_focus">False</property>
-                                            <property name="valign">center</property>
-                                            <property name="resource">/com/endlessm/appstore/icon_installed_24x24.png</property>
-                                            <style>
-                                              <class name="header-installed-image"/>
-                                            </style>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>

--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -178,10 +178,6 @@
     color: #ccc;
 }
 
-.header-installed-image {
-    padding-top: 8px;
-}
-
 .app-cell-title {
     font-weight: bold;
     font-size: 13px;


### PR DESCRIPTION
This is not necessary anymore due to the "Installed" category. Besides,
it was showing up by mistake as well for apps that were not installed yet.

[endlessm/eos-shell#3552]
