### PR TITLE
Show "Install" instead of "Update" for non installed apps

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -242,14 +242,16 @@ const AppListBoxRow = new Lang.Class({
                 break;
 
             case EosAppStorePrivate.AppState.UPDATABLE:
-                this._installButtonLabel.set_text(_("Update app"));
-                this._installButton.show();
-
-                // like the .INSTALLED case, we only show the 'delete app'
-                // button if the app does not have a launcher on the desktop
-                if (!this._model.hasLauncher(this._appId)) {
+                if (this._model.hasLauncher(this._appId)) {
+                    this._installButtonLabel.set_text(_("Update app"));
+                }
+                else {
+                    this._installButtonLabel.set_text(_("Install app"));
+                    // like the .INSTALLED case, we only show the 'delete app'
+                    // button if the app does not have a launcher on the desktop
                     this._removeButton.show();
                 }
+                this._installButton.show();
                 break;
 
             case EosAppStorePrivate.AppState.UNKNOWN:


### PR DESCRIPTION
When a new bundle version is available for an application that is not installed
in the desktop, show "Install app" instead of "Update app".

[endlessm/eos-shell#3538]
