### PR TITLE
NewSiteBox: Use the title of the website from urlLabel to install a link

### DIFF
--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -416,7 +416,7 @@ const NewSiteBox = new Lang.Class({
     },
 
     _onSiteAdd: function() {
-        let title = this._urlEntry.get_text();
+        let title = this._urlLabel.get_label();
 
         let desktopId = this._webHelper.save(title);
         this._weblinkListModel.install(desktopId, function() {});


### PR DESCRIPTION
In the past we took the title from a GtkEntry that might be visible (if
the user decided not to use the suggested title) but now that entry is
gone and we need to take the title of the website from the GtkLabel instead.

[endlessm/eos-shell#3242]
