### PR TITLE
eos-app-list-model: Never return eos-app- prefixed filenames

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1271,12 +1271,21 @@ app_get_localized_id_for_installed_app (EosAppListModel *model,
                                         const gchar *desktop_id)
 {
   GDesktopAppInfo *info;
+  char *localized_id;
 
-  info = eos_app_list_model_get_app_info (model, desktop_id);
-  if (info != NULL)
+  info = g_hash_table_lookup (model->gio_apps, desktop_id);
+  if (info)
+    goto out;
+
+  localized_id = localized_id_from_desktop_id (desktop_id);
+  info = g_hash_table_lookup (model->gio_apps, localized_id);
+  g_free (localized_id);
+
+ out:
+  if (info)
     return g_app_info_get_id (G_APP_INFO (info));
-
-  return NULL;
+  else
+    return NULL;
 }
 
 gboolean


### PR DESCRIPTION
The way app_get_localized_id_for_installed_app would return our internal
eos-app-\* prefixed override .desktop files first, and thus we'd
install and add eos-app-*.desktop files to the desktop, which is wrong.

Be more careful when looking up the localized app ID to make sure we
never install an eos-app-\* prefixed override .desktop file.

[endlessm/eos-shell#3846]
