### PR TITLE
appFrame: Notify errors only if they are not cancellations

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -497,7 +497,7 @@ const AppListBoxRow = new Lang.Class({
         if (error &&
             (error.matches(Gio.io_error_quark(),
                            Gio.IOErrorEnum.CANCELLED) ||
-             error.matched(EosAppStorePrivate.app_list_model_error_quark(),
+             error.matches(EosAppStorePrivate.app_list_model_error_quark(),
                            EosAppStorePrivate.AppListModelError.CANCELLED))) {
             return;
         }


### PR DESCRIPTION
[endlessm/eos-shell#3925]
