### PR TITLE
Dot not show buttons buttons when transactioning

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -161,6 +161,11 @@ const AppListBoxRow = new Lang.Class({
 
     _updateState: function() {
         this.appState = this._model.getState(this._appId);
+
+        if (this.hasTransactionInProgress) {
+            this._installButton.hide();
+            this._removeButton.hide();
+        }
     },
 
     _downloadProgress: function(model, appid, progress, current, total) {


### PR DESCRIPTION
If there is a transaction (install/remove/update) in progress, do not
show the Install/Update/Remove buttons.

[endlessm/eos-shell#3932]
