### PR TITLE
appStoreWindow: flip window gravity on RTL

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -76,10 +76,13 @@ const AppStoreWindow = new Lang.Class({
     ],
 
     _init: function(app) {
+        let rtl = Gtk.Widget.get_default_direction();
+
         this.parent({ application: app,
                         type_hint: Gdk.WindowTypeHint.DOCK,
                              type: Gtk.WindowType.TOPLEVEL,
-                             role: SIDE_COMPONENT_ROLE
+                             role: SIDE_COMPONENT_ROLE,
+                             gravity: rtl ? Gdk.Gravity.NORTH_EAST : Gdk.Gravity.NORTH_WEST
                     });
 
         this.initTemplate({ templateRoot: 'main-frame', bindChildren: true, connectSignals: true, });


### PR DESCRIPTION
The app store window is special in that it extends out from a screen
edge. When the content in the window is too large and the window needs
to be resized, the window gravity determines the direciton the new size
will be extended towards.
In case we're using an RTL layout, use an eastern gravity instead of the
western default, so that the window will extend in the right direction
whenever the content is larger than the current allocation.

[endlessm/eos-shell#4051]
