### PR TITLE
app-list-model: don't check for launcher presence before adding to shell

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1721,13 +1721,10 @@ add_app_thread_func (GTask *task,
         }
      }
 
-  if (!app_has_launcher (model, desktop_id))
+  if (!add_app_to_shell (model, desktop_id, cancellable, &error))
     {
-      if (!add_app_to_shell (model, desktop_id, cancellable, &error))
-        {
-          g_task_return_error (task, error);
-          return;
-        }
+      g_task_return_error (task, error);
+      return;
     }
 
   g_task_return_boolean (task, TRUE);


### PR DESCRIPTION
The shell is the ultimate arbiter on where a launcher goes in case it's
already specified in the layout. In fact, it already handles that case
just fine, appending it to the desktop layout as desired.
Just remove this check, since we don't want an icon that was previously
inside a folder, or is in a folder in the default layout, to end up in
that folder again when it's later added from the store.

[endlessm/eos-shell#3627]
