### PR TITLE
appStoreWindow: Make sure to dispose our cairo context

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -298,7 +298,9 @@ const AppStoreWindow = new Lang.Class({
             this.content_box.add(this._stack);
         }
 
-        return this.parent(cr);
+        this.parent(cr);
+        cr.$dispose();
+        return true;
     },
 
     show: function() {


### PR DESCRIPTION
Otherwise, we leak the temporary Pixmap we buffer all our changes to,
which can easily cause Xorg to rise up to 1G of memory when playing
around on the app store. This can quickly exhaust all memory on a small
system like our Amlogic board, causing the system to hang while the
kernel frees memory, and the OOM killer to kick in and kill Xorg.

[endlessm/eos-shell#4289]
