### PR TITLE
App Store: Fix for failures in updating apps through the app store

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1983,14 +1983,15 @@ update_app_from_manager (EosAppListModel *self,
   if (retval && error == NULL)
     return TRUE;
 
-  if (error) {
-    eos_app_log_info_message ("Update of %s using deltas failed: %s",
-                              desktop_id,
-                              error->message);
+  if (error)
+    {
+      eos_app_log_info_message ("Update of %s using deltas failed: %s",
+                                desktop_id,
+                                error->message);
 
-    /* We don't care what the problem was (at this time) */
-    g_clear_error (error_out);
-  }
+      /* We don't care what the problem was (at this time) */
+      g_clear_error (&error);
+    }
 
   eos_app_log_info_message ("Trying full update of %s",
                             desktop_id);


### PR DESCRIPTION
If the outgoing error wasn't initialized, the return value for its check
could be non-NULL and cause the code to behave as if there was an error.
This change ensures that our error check isn't dependent on the outside
error initial value.

[endlessm/eos-shell#4466]
