### PR TITLE
eos-app-utils: underscore is a valid character in app IDs

### DIFF
--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -750,7 +750,7 @@ eos_get_all_updates_uri (void)
 static gboolean
 is_app_id (const char *appid)
 {
-  static const char alsoallowed[] = "-+.";
+  static const char alsoallowed[] = "_-+.";
   static const char *reserveddirs[] = { "bin", "share", "lost+found", "xdg", };
 
   if (!appid || appid[0] == '\0')


### PR DESCRIPTION
Now that we have app IDs that e.g. end with es_GT, we need to update
ithis heuristic.

[endlessm/eos-shell#4928]
