### PR TITLE
App Store: Made app description closing reset the header properly

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -771,6 +771,8 @@ const AppCategoryFrame = new Lang.Class({
             let appBox = new AppListBoxRow(this._model, cell.app_info);
             appBox.show();
 
+            appBox.connect('destroy', Lang.bind(this, this._showGrid));
+
             this._stack.add_named(appBox, cell.desktop_id);
         }
 


### PR DESCRIPTION
Previously when the app description dialog was closed, the main window
had no idea that it happened so the title would remain the old app name
and the icon so now we tie into the 'destroy' signal to make sure we
clean up properly.

[endlessm/eos-shell#4674]
