### PR TITLE
App Store: We now omit empty weblink categories

### DIFF
--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -537,7 +537,7 @@ eos_link_load_content (EosLinkCategory category)
 
   if (i >= n_elements)
     {
-      g_critical ("Unable to find category '%s'", category_name);
+      eos_app_log_info_message ("Unable to find category '%s'", category_name);
       goto out;
     }
 


### PR DESCRIPTION
Previously we would show the weblink buttons but now we just ignore
those. In the process, some of the empty category warnings were snubbed
as well.

[endlessm/eos-shell#4624]
