### PR TITLE
model: Pass the download directory

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1842,7 +1842,7 @@ get_bundle_artifacts (EosAppListModel *self,
   eos_app_log_info_message ("Completing transaction with eam");
 
   eos_app_manager_transaction_call_complete_transaction_sync (transaction,
-                                                              bundle_path,
+                                                              eos_get_bundle_download_dir (),
                                                               &retval,
                                                               cancellable,
                                                               &error);


### PR DESCRIPTION
The app manager will generate the name of the bundle artifacts starting
from the location and the application id; passing the location of the
bundle file is not going to work without special-casing the whole thing
inside the app manager.

[endlessm/eos-shell#5014]
