### PR TITLE
App Store: Fix problems in network detection for install/update button sensitivity

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -366,6 +366,9 @@ const AppListBoxRow = new Lang.Class({
                     this._installButton.set_sensitive(false);
                     this._installButton.set_tooltip_text(BUTTON_TOOLTIP_NO_SPACE);
                 }
+                else {
+                    this._installButton.set_sensitive(true);
+                }
 
                 this._installButton.show();
 
@@ -373,10 +376,9 @@ const AppListBoxRow = new Lang.Class({
 
             case EosAppStorePrivate.AppState.UPDATABLE:
                 if (this.appInfo.get_has_launcher()) {
-                    if (!this._networkAvailable) {
-                        this._installButton.set_sensitive(false);
+                    this._installButton.set_sensitive(this._networkAvailable);
+                    if (!this._networkAvailable)
                         this._installButton.set_tooltip_text(BUTTON_TOOLTIP_NO_NETWORK);
-                    }
 
                     this._installButtonLabel.set_text(BUTTON_LABEL_UPDATE);
                 }


### PR DESCRIPTION
Old code assumed that we won't have a flapping connection so once the
install/update buttons were set insensitive, there was no way for them
to become sensitive again even after network comes back.

[endlessm/eos-shell#5211]
