### PR TITLE
App Store: Fixed GTK ui deprecation warnings

### DIFF
--- a/data/eos-app-store-list-row.ui
+++ b/data/eos-app-store-list-row.ui
@@ -34,7 +34,7 @@
                     <child>
                       <object class="GtkImage" id="_screenshotImage">
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-missing-image</property>
+                        <property name="icon_name">missing-image</property>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -170,7 +170,6 @@
                                   <object class="GtkButton" id="_installProgressCancel">
                                     <property name="visible">False</property>
                                     <property name="can_focus">True</property>
-                                    <property name="xalign">0</property>
                                     <property name="label" translatable="yes">Cancel</property>
                                     <signal name="clicked" handler="_onInstallCancelButtonClicked" swapped="no"/>
                                     <style>

--- a/data/eos-app-store-main-window.ui
+++ b/data/eos-app-store-main-window.ui
@@ -119,7 +119,7 @@
                                 <child>
                                   <object class="GtkImage" id="header-icon">
                                     <property name="can_focus">False</property>
-                                    <property name="stock">gtk-missing-image</property>
+                                    <property name="icon-name">missing-image</property>
                                     <style>
                                       <class name="header-icon"/>
                                     </style>


### PR DESCRIPTION
They were just too annoying and required simple fixes (stock ->
icon_name & removal of xalign on cancel button)

[endlessm/eos-shell#5227]
