### PR TITLE
model: Update the EAM transaction API

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1117,8 +1117,16 @@ get_bundle_artifacts (EosAppListModel *self,
 
   eos_app_log_info_message ("Completing transaction with eam");
 
+  GVariantBuilder opts;
+  g_variant_builder_init (&opts, G_VARIANT_TYPE ("(a{sv})"));
+  g_variant_builder_open (&opts, G_VARIANT_TYPE ("a{sv}"));
+  g_variant_builder_add (&opts, "{sv}", "BundlePath", g_variant_new_string (bundle_path));
+  g_variant_builder_add (&opts, "{sv}", "SignaturePath", g_variant_new_string (signature_path));
+  g_variant_builder_add (&opts, "{sv}", "ChecksumPath", g_variant_new_string (sha256_path));
+  g_variant_builder_close (&opts);
+
   eos_app_manager_transaction_call_complete_transaction_sync (transaction,
-                                                              eos_get_bundle_download_dir (),
+                                                              g_variant_builder_end (&opts),
                                                               &retval,
                                                               cancellable,
                                                               &error);

--- a/data/eam-transaction-interface.xml
+++ b/data/eam-transaction-interface.xml
@@ -7,7 +7,7 @@
   <interface name="com.endlessm.AppManager.Transaction">
 
     <method name="CompleteTransaction">
-      <arg type="s" name="path" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
       <arg type="b" name="success" direction="out"/>
     </method>
 


### PR DESCRIPTION
EAM changed the transaction DBus API to list all the paths to the
various bundle artifacts.

[endlessm/eos-shell#5238]
