### PR TITLE
App Store: Fixed scrollbar border issues resulting from theming changes

### DIFF
--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -37,6 +37,7 @@
     -GtkRange-slider-width: 8;
     -GtkRange-stepper-spacing: 15;
     -GtkRange-stepper-size: 0;
+    -GtkRange-trough-border: 0;
     -GtkRange-trough-under-steppers: false;
 
     -GtkScrollbar-min-slider-length: 115;
@@ -49,11 +50,13 @@
     background-repeat: no-repeat;
     background-position: 50%;
 
+    margin: 0;
     border-width: 0;
     box-shadow: inset 0 0 2px 0 alpha(black, 0.25);
 }
 
 .scrollbar.trough {
+    border-width: 0;
     border-radius: 20px;
     background-color: alpha(black, 0.20);
     box-shadow: inset 0 0 2px 0 alpha(black, 0.25);


### PR DESCRIPTION
We needed to apply some more overrides for the theme to get back to our
original look-and-feel though the scrollbar is a bit smaller now but
messing with the hardcoded resolution settings seemed to be an overkill
if we'll redesign parts of it soon.

[endlessm/eos-shell#5267]
