### PR TITLE
App Store: Fixed handling of xdelta bundle download extensions

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1084,7 +1084,9 @@ download_bundle (EosAppListModel *self,
       return NULL;
     }
 
-  char *bundle_name = g_strconcat (app_id, ".bundle", NULL);
+  char *extension = use_delta ? ".xdelta": ".bundle";
+  char *bundle_name = g_strconcat (app_id, extension, NULL);
+
   char *bundle_path = g_build_filename (eos_get_bundle_download_dir (), bundle_name, NULL);
   g_free (bundle_name);
 


### PR DESCRIPTION
Old code would always hardcode '.bundle' as the file extension during
artifact downloads which broke handling of deltas since EAM code depends on
this distinction to choose what action to invoke.

[endlessm/eos-shell#5312]
