### PR TITLE
eos-flexy-grid: Don't redraw our entire grid when changing prelight

### DIFF
--- a/EosAppStore/lib/eos-flexy-grid.c
+++ b/EosAppStore/lib/eos-flexy-grid.c
@@ -100,8 +100,6 @@ eos_flexy_grid_update_cell_prelight (EosFlexyGrid *grid,
 
       g_signal_emit (grid, grid_signals[CELL_SELECTED], 0, NULL);
     }
-
-  gtk_widget_queue_draw (GTK_WIDGET (grid));
 }
 
 static inline void


### PR DESCRIPTION
The grid cell already redraws when it wants to, so we shouldn't bother
redrawing everything that hasn't.

[endlessm/eos-shell#5259]
