### PR TITLE
Rename app store to app center

### DIFF
--- a/EosAppStore/environment.js
+++ b/EosAppStore/environment.js
@@ -19,7 +19,7 @@ function init() {
     window.ngettext = Gettext.ngettext;
 
     GLib.set_prgname('eos-app-store');
-    GLib.set_application_name(_("App Store"));
+    GLib.set_application_name(_("App Center"));
 
     GObject.type_ensure(EosAppStorePrivate.VerticalStackSwitcher);
 

--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -516,7 +516,7 @@ load_user_capabilities (EosAppListModel *self,
     {
       g_set_error_literal (error_out, EOS_APP_LIST_MODEL_ERROR,
                            EOS_APP_LIST_MODEL_ERROR_FAILED,
-                           _("The app store has detected a fatal error and "
+                           _("The app center has detected a fatal error and "
                              "cannot continue with the installation. Please, "
                              "restart your system. If the problem persists, "
                              "please contact support."));
@@ -1329,7 +1329,7 @@ install_latest_app_version (EosAppListModel *self,
   if (proxy == NULL ||
       !g_file_test (eos_get_bundles_dir (), G_FILE_TEST_EXISTS))
     {
-      external_message = _("The app store has detected a fatal error and "
+      external_message = _("The app center has detected a fatal error and "
                            "cannot continue. Please, "
                            "restart your system. If the problem persists, "
                            "please contact support.");
@@ -1524,7 +1524,7 @@ remove_app_from_manager (EosAppListModel *self,
   if (proxy == NULL ||
       !g_file_test (eos_get_bundles_dir (), G_FILE_TEST_EXISTS))
     {
-      external_message = _("The app store has detected a fatal error and "
+      external_message = _("The app center has detected a fatal error and "
                            "cannot continue. Please, "
                            "restart your system. If the problem persists, "
                            "please contact support.");

--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -1560,7 +1560,7 @@ static const struct {
   const EosAppCategory category;
   const char *id;
 } categories[] = {
-  /* Translators: use the same string used to install the app store content JSON */
+  /* Translators: use the same string used to install the app center content JSON */
   { EOS_APP_CATEGORY_EDUCATION,     N_("Education") },
   { EOS_APP_CATEGORY_GAMES,         N_("Games") },
   { EOS_APP_CATEGORY_RESOURCES,     N_("Resources") },

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,10 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-app-store\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-14 01:22+0000\n"
-"PO-Revision-Date: 2015-07-14 01:22+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: Arabic (http://www.transifex.com/p/eos-app-store/language/ar/)\n"
+"POT-Creation-Date: 2015-07-21 01:24+0000\n"
+"PO-Revision-Date: 2015-07-21 17:20+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Arabic (http://www.transifex.com/projects/p/eos-app-store/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -146,20 +146,21 @@ msgstr "المواقع"
 msgid "Folders"
 msgstr "المجلدات "
 
-#. Translators: use the same string used to install the app store content JSON
-#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1452
+#. Translators: use the same string used to install the app center content
+#. JSON
+#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1564
 msgid "Education"
 msgstr "التعليم "
 
-#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1453
+#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1565
 msgid "Games"
 msgstr "ألعاب"
 
-#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1454
+#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1566
 msgid "Resources"
 msgstr "الموارد"
 
-#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1455
+#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1567
 msgid "Utilities"
 msgstr "المرافق"
 
@@ -188,7 +189,7 @@ msgid "Local"
 msgstr "محلي"
 
 #: ../EosAppStore/environment.js:22
-msgid "App Store"
+msgid "App Center"
 msgstr "متجر التطبيقات"
 
 #: ../EosAppStore/folderFrame.js:41
@@ -235,7 +236,7 @@ msgstr "تثبيت المواقع"
 
 #: ../EosAppStore/lib/eos-app-list-model.c:519
 msgid ""
-"The app store has detected a fatal error and cannot continue with the "
+"The app center has detected a fatal error and cannot continue with the "
 "installation. Please, restart your system. If the problem persists, please "
 "contact support."
 msgstr ""
@@ -263,82 +264,86 @@ msgstr "ليس هناك توقيع متوفر من أجل '%s'"
 msgid "Application bundle '%s' could not be downloaded"
 msgstr "تعذر تنزيل حزمة التطبيق '%s'"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1238
+#: ../EosAppStore/lib/eos-app-list-model.c:1188
+msgid "No space available for installing the app"
+msgstr ""
+
+#: ../EosAppStore/lib/eos-app-list-model.c:1257
 #, c-format
 msgid "Application '%s' could not be installed"
 msgstr "تعذر تثبيت التطبيق '%s'"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1245
+#: ../EosAppStore/lib/eos-app-list-model.c:1264
 #, c-format
 msgid "Application '%s' could not be installed. %s"
 msgstr "تطبيق '%s' لم يمكن تثبيته. %s "
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1270
+#: ../EosAppStore/lib/eos-app-list-model.c:1289
 #, c-format
 msgid "Application '%s' could not be removed"
 msgstr "لا يمكن إزالة تطبيق '%s'"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1277
+#: ../EosAppStore/lib/eos-app-list-model.c:1296
 #, c-format
 msgid "Application '%s' could not be removed. %s"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1301
-#: ../EosAppStore/lib/eos-app-list-model.c:1349
+#: ../EosAppStore/lib/eos-app-list-model.c:1320
+#: ../EosAppStore/lib/eos-app-list-model.c:1368
 msgid "You must be an administrator to install applications"
 msgstr "لابد أن تكون مسؤولاً للتُثبِّت التطبيق"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1313
-#: ../EosAppStore/lib/eos-app-list-model.c:1508
+#: ../EosAppStore/lib/eos-app-list-model.c:1332
+#: ../EosAppStore/lib/eos-app-list-model.c:1527
 msgid ""
-"The app store has detected a fatal error and cannot continue. Please, "
+"The app center has detected a fatal error and cannot continue. Please, "
 "restart your system. If the problem persists, please contact support."
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1496
-#: ../EosAppStore/lib/eos-app-list-model.c:1526
+#: ../EosAppStore/lib/eos-app-list-model.c:1515
+#: ../EosAppStore/lib/eos-app-list-model.c:1545
 msgid "You must be an administrator to remove applications"
 msgstr "لابد أن تكون مسؤولاً حتى تزيل التطبيق"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1659
-#: ../EosAppStore/lib/eos-app-list-model.c:1727
+#: ../EosAppStore/lib/eos-app-list-model.c:1678
+#: ../EosAppStore/lib/eos-app-list-model.c:1746
 #, c-format
 msgid "App %s not installable"
 msgstr "التطبيق ليس %s قابلا للتثبيت"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1671
+#: ../EosAppStore/lib/eos-app-list-model.c:1690
 #, c-format
 msgid "App %s already installed"
 msgstr "التطبيق %s مثبت مسبقا"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1738
+#: ../EosAppStore/lib/eos-app-list-model.c:1757
 #, c-format
 msgid "App %s is up to date"
 msgstr "التطبيق %s حديث"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1809
-#: ../EosAppStore/lib/eos-app-list-model.c:1841
+#: ../EosAppStore/lib/eos-app-list-model.c:1828
+#: ../EosAppStore/lib/eos-app-list-model.c:1860
 #, c-format
 msgid "App %s is not installed"
 msgstr "التطبيق %s غير مثبت"
 
-#: ../EosAppStore/lib/eos-app-utils.c:879
+#: ../EosAppStore/lib/eos-app-utils.c:991
 msgid "Operation cancelled"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:901
+#: ../EosAppStore/lib/eos-app-utils.c:1013
 msgid "Updates meta record did not contain expected structure"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:916
+#: ../EosAppStore/lib/eos-app-utils.c:1028
 msgid "Updates meta record did not contain expected attributes"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:932
+#: ../EosAppStore/lib/eos-app-utils.c:1044
 msgid "Updates meta record did not contain valid monotonic_id attribute value"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:1744
+#: ../EosAppStore/lib/eos-app-utils.c:1856
 #, c-format
 msgid "Not enough space on device for downloading app"
 msgstr "لا توجد مساحة كافية على الجهاز لتنزيل التطبيق"

--- a/po/eos-app-store.pot
+++ b/po/eos-app-store.pot
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Folders"
 msgstr ""
 
-#. Translators: use the same string used to install the app store content JSON
+#. Translators: use the same string used to install the app center content JSON
 #: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1564
 msgid "Education"
 msgstr ""
@@ -187,7 +187,7 @@ msgid "Local"
 msgstr ""
 
 #: ../EosAppStore/environment.js:22
-msgid "App Store"
+msgid "App Center"
 msgstr ""
 
 #: ../EosAppStore/folderFrame.js:41
@@ -234,7 +234,7 @@ msgstr ""
 
 #: ../EosAppStore/lib/eos-app-list-model.c:519
 msgid ""
-"The app store has detected a fatal error and cannot continue with the "
+"The app center has detected a fatal error and cannot continue with the "
 "installation. Please, restart your system. If the problem persists, please "
 "contact support."
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 #: ../EosAppStore/lib/eos-app-list-model.c:1332
 #: ../EosAppStore/lib/eos-app-list-model.c:1527
 msgid ""
-"The app store has detected a fatal error and cannot continue. Please, "
+"The app center has detected a fatal error and cannot continue. Please, "
 "restart your system. If the problem persists, please contact support."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -23,10 +23,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-app-store\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-14 01:22+0000\n"
-"PO-Revision-Date: 2015-07-14 01:22+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/p/eos-app-store/language/es/)\n"
+"POT-Creation-Date: 2015-07-21 01:24+0000\n"
+"PO-Revision-Date: 2015-07-21 17:20+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/eos-app-store/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -161,20 +161,21 @@ msgstr "Sitios web"
 msgid "Folders"
 msgstr "Carpetas"
 
-#. Translators: use the same string used to install the app store content JSON
-#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1452
+#. Translators: use the same string used to install the app center content
+#. JSON
+#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1564
 msgid "Education"
 msgstr "Educación"
 
-#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1453
+#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1565
 msgid "Games"
 msgstr "Juegos"
 
-#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1454
+#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1566
 msgid "Resources"
 msgstr "Recursos"
 
-#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1455
+#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1567
 msgid "Utilities"
 msgstr "Herramientas"
 
@@ -203,7 +204,7 @@ msgid "Local"
 msgstr "Local"
 
 #: ../EosAppStore/environment.js:22
-msgid "App Store"
+msgid "App Center"
 msgstr "Centro de programas"
 
 #: ../EosAppStore/folderFrame.js:41
@@ -250,7 +251,7 @@ msgstr "Instalar sitios web"
 
 #: ../EosAppStore/lib/eos-app-list-model.c:519
 msgid ""
-"The app store has detected a fatal error and cannot continue with the "
+"The app center has detected a fatal error and cannot continue with the "
 "installation. Please, restart your system. If the problem persists, please "
 "contact support."
 msgstr "El centro de programas ha detectado un error grave y no puede continuar con la instalación. Por favor, reinicia tu sistema. Si el problema persiste, ponte en contacto con soporte."
@@ -278,82 +279,86 @@ msgstr "No hay ninguna firma disponible para el programa '%s'"
 msgid "Application bundle '%s' could not be downloaded"
 msgstr "No fue posible descargar el programa '%s'"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1238
+#: ../EosAppStore/lib/eos-app-list-model.c:1188
+msgid "No space available for installing the app"
+msgstr ""
+
+#: ../EosAppStore/lib/eos-app-list-model.c:1257
 #, c-format
 msgid "Application '%s' could not be installed"
 msgstr "El programa '%s' no se pudo instalar "
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1245
+#: ../EosAppStore/lib/eos-app-list-model.c:1264
 #, c-format
 msgid "Application '%s' could not be installed. %s"
 msgstr "El programa '%s' no se pudo instalar. %s"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1270
+#: ../EosAppStore/lib/eos-app-list-model.c:1289
 #, c-format
 msgid "Application '%s' could not be removed"
 msgstr "El programa '%s' no se pudo eliminar"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1277
+#: ../EosAppStore/lib/eos-app-list-model.c:1296
 #, c-format
 msgid "Application '%s' could not be removed. %s"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1301
-#: ../EosAppStore/lib/eos-app-list-model.c:1349
+#: ../EosAppStore/lib/eos-app-list-model.c:1320
+#: ../EosAppStore/lib/eos-app-list-model.c:1368
 msgid "You must be an administrator to install applications"
 msgstr "Tienes que ser un administrador para instalar programas"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1313
-#: ../EosAppStore/lib/eos-app-list-model.c:1508
+#: ../EosAppStore/lib/eos-app-list-model.c:1332
+#: ../EosAppStore/lib/eos-app-list-model.c:1527
 msgid ""
-"The app store has detected a fatal error and cannot continue. Please, "
+"The app center has detected a fatal error and cannot continue. Please, "
 "restart your system. If the problem persists, please contact support."
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1496
-#: ../EosAppStore/lib/eos-app-list-model.c:1526
+#: ../EosAppStore/lib/eos-app-list-model.c:1515
+#: ../EosAppStore/lib/eos-app-list-model.c:1545
 msgid "You must be an administrator to remove applications"
 msgstr "Tienes que ser un administrador para quitar programas"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1659
-#: ../EosAppStore/lib/eos-app-list-model.c:1727
+#: ../EosAppStore/lib/eos-app-list-model.c:1678
+#: ../EosAppStore/lib/eos-app-list-model.c:1746
 #, c-format
 msgid "App %s not installable"
 msgstr "No es posible instalar el programa %s"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1671
+#: ../EosAppStore/lib/eos-app-list-model.c:1690
 #, c-format
 msgid "App %s already installed"
 msgstr "El programa %s ya está instalado"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1738
+#: ../EosAppStore/lib/eos-app-list-model.c:1757
 #, c-format
 msgid "App %s is up to date"
 msgstr "El programa %s ya está actualizado"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1809
-#: ../EosAppStore/lib/eos-app-list-model.c:1841
+#: ../EosAppStore/lib/eos-app-list-model.c:1828
+#: ../EosAppStore/lib/eos-app-list-model.c:1860
 #, c-format
 msgid "App %s is not installed"
 msgstr "El programa %s no está instalado"
 
-#: ../EosAppStore/lib/eos-app-utils.c:879
+#: ../EosAppStore/lib/eos-app-utils.c:991
 msgid "Operation cancelled"
 msgstr "Operación cancelada"
 
-#: ../EosAppStore/lib/eos-app-utils.c:901
+#: ../EosAppStore/lib/eos-app-utils.c:1013
 msgid "Updates meta record did not contain expected structure"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:916
+#: ../EosAppStore/lib/eos-app-utils.c:1028
 msgid "Updates meta record did not contain expected attributes"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:932
+#: ../EosAppStore/lib/eos-app-utils.c:1044
 msgid "Updates meta record did not contain valid monotonic_id attribute value"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:1744
+#: ../EosAppStore/lib/eos-app-utils.c:1856
 #, c-format
 msgid "Not enough space on device for downloading app"
 msgstr "No hay suficiente espacio en la computadora para descargar este programa"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,10 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-app-store\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-14 01:22+0000\n"
-"PO-Revision-Date: 2015-07-14 01:22+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: French (http://www.transifex.com/p/eos-app-store/language/fr/)\n"
+"POT-Creation-Date: 2015-07-21 01:24+0000\n"
+"PO-Revision-Date: 2015-07-21 17:20+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/eos-app-store/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -146,20 +146,21 @@ msgstr "Sites internet"
 msgid "Folders"
 msgstr "Dossiers"
 
-#. Translators: use the same string used to install the app store content JSON
-#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1452
+#. Translators: use the same string used to install the app center content
+#. JSON
+#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1564
 msgid "Education"
 msgstr "Formation"
 
-#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1453
+#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1565
 msgid "Games"
 msgstr "Jeux"
 
-#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1454
+#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1566
 msgid "Resources"
 msgstr "Ressources"
 
-#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1455
+#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1567
 msgid "Utilities"
 msgstr "Utilitaires"
 
@@ -188,8 +189,8 @@ msgid "Local"
 msgstr "Régional"
 
 #: ../EosAppStore/environment.js:22
-msgid "App Store"
-msgstr "App Store"
+msgid "App Center"
+msgstr "App Center"
 
 #: ../EosAppStore/folderFrame.js:41
 msgid "Name of folder"
@@ -235,7 +236,7 @@ msgstr "Installer les sites internet"
 
 #: ../EosAppStore/lib/eos-app-list-model.c:519
 msgid ""
-"The app store has detected a fatal error and cannot continue with the "
+"The app center has detected a fatal error and cannot continue with the "
 "installation. Please, restart your system. If the problem persists, please "
 "contact support."
 msgstr ""
@@ -263,82 +264,86 @@ msgstr "Pas de signature disponible pour l'application '%s' "
 msgid "Application bundle '%s' could not be downloaded"
 msgstr "Le lot d'applications « %s » n'a pas pu être téléchargé"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1238
+#: ../EosAppStore/lib/eos-app-list-model.c:1188
+msgid "No space available for installing the app"
+msgstr ""
+
+#: ../EosAppStore/lib/eos-app-list-model.c:1257
 #, c-format
 msgid "Application '%s' could not be installed"
 msgstr "L'application « %s » n'a pas pu être installée"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1245
+#: ../EosAppStore/lib/eos-app-list-model.c:1264
 #, c-format
 msgid "Application '%s' could not be installed. %s"
 msgstr "L'application '%s' n'a pu être installée. %s"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1270
+#: ../EosAppStore/lib/eos-app-list-model.c:1289
 #, c-format
 msgid "Application '%s' could not be removed"
 msgstr "L'application « %s » n'a pas pu être éliminée"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1277
+#: ../EosAppStore/lib/eos-app-list-model.c:1296
 #, c-format
 msgid "Application '%s' could not be removed. %s"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1301
-#: ../EosAppStore/lib/eos-app-list-model.c:1349
+#: ../EosAppStore/lib/eos-app-list-model.c:1320
+#: ../EosAppStore/lib/eos-app-list-model.c:1368
 msgid "You must be an administrator to install applications"
 msgstr "Vous devez être un administrateur pour installer des applications"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1313
-#: ../EosAppStore/lib/eos-app-list-model.c:1508
+#: ../EosAppStore/lib/eos-app-list-model.c:1332
+#: ../EosAppStore/lib/eos-app-list-model.c:1527
 msgid ""
-"The app store has detected a fatal error and cannot continue. Please, "
+"The app center has detected a fatal error and cannot continue. Please, "
 "restart your system. If the problem persists, please contact support."
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1496
-#: ../EosAppStore/lib/eos-app-list-model.c:1526
+#: ../EosAppStore/lib/eos-app-list-model.c:1515
+#: ../EosAppStore/lib/eos-app-list-model.c:1545
 msgid "You must be an administrator to remove applications"
 msgstr "Vous devez être un administrateur pour supprimer des applications"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1659
-#: ../EosAppStore/lib/eos-app-list-model.c:1727
+#: ../EosAppStore/lib/eos-app-list-model.c:1678
+#: ../EosAppStore/lib/eos-app-list-model.c:1746
 #, c-format
 msgid "App %s not installable"
 msgstr "L'application «%s» ne peut pas être installée"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1671
+#: ../EosAppStore/lib/eos-app-list-model.c:1690
 #, c-format
 msgid "App %s already installed"
 msgstr "« %s » de l'application est déjà installé"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1738
+#: ../EosAppStore/lib/eos-app-list-model.c:1757
 #, c-format
 msgid "App %s is up to date"
 msgstr "« %s » de l'application est mis à jour"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1809
-#: ../EosAppStore/lib/eos-app-list-model.c:1841
+#: ../EosAppStore/lib/eos-app-list-model.c:1828
+#: ../EosAppStore/lib/eos-app-list-model.c:1860
 #, c-format
 msgid "App %s is not installed"
 msgstr "« %s » de l'application n'est pas installé"
 
-#: ../EosAppStore/lib/eos-app-utils.c:879
+#: ../EosAppStore/lib/eos-app-utils.c:991
 msgid "Operation cancelled"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:901
+#: ../EosAppStore/lib/eos-app-utils.c:1013
 msgid "Updates meta record did not contain expected structure"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:916
+#: ../EosAppStore/lib/eos-app-utils.c:1028
 msgid "Updates meta record did not contain expected attributes"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:932
+#: ../EosAppStore/lib/eos-app-utils.c:1044
 msgid "Updates meta record did not contain valid monotonic_id attribute value"
 msgstr ""
 
-#: ../EosAppStore/lib/eos-app-utils.c:1744
+#: ../EosAppStore/lib/eos-app-utils.c:1856
 #, c-format
 msgid "Not enough space on device for downloading app"
 msgstr "Pas assez d'espace sur l'appareil pour télécharger l'application"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,10 +15,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-app-store\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-14 01:22+0000\n"
-"PO-Revision-Date: 2015-07-14 01:22+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/p/eos-app-store/language/pt_BR/)\n"
+"POT-Creation-Date: 2015-07-21 01:24+0000\n"
+"PO-Revision-Date: 2015-07-21 17:21+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/eos-app-store/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -153,20 +153,21 @@ msgstr "Sites"
 msgid "Folders"
 msgstr "Pastas"
 
-#. Translators: use the same string used to install the app store content JSON
-#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1452
+#. Translators: use the same string used to install the app center content
+#. JSON
+#: ../EosAppStore/categories.js:12 ../EosAppStore/lib/eos-app-utils.c:1564
 msgid "Education"
 msgstr "Educação"
 
-#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1453
+#: ../EosAppStore/categories.js:19 ../EosAppStore/lib/eos-app-utils.c:1565
 msgid "Games"
 msgstr "Jogos"
 
-#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1454
+#: ../EosAppStore/categories.js:26 ../EosAppStore/lib/eos-app-utils.c:1566
 msgid "Resources"
 msgstr "Recursos"
 
-#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1455
+#: ../EosAppStore/categories.js:33 ../EosAppStore/lib/eos-app-utils.c:1567
 msgid "Utilities"
 msgstr "Utilidades"
 
@@ -195,7 +196,7 @@ msgid "Local"
 msgstr "Localidade"
 
 #: ../EosAppStore/environment.js:22
-msgid "App Store"
+msgid "App Center"
 msgstr "Central de Programas"
 
 #: ../EosAppStore/folderFrame.js:41
@@ -242,7 +243,7 @@ msgstr "Adicionar atalhos para sites"
 
 #: ../EosAppStore/lib/eos-app-list-model.c:519
 msgid ""
-"The app store has detected a fatal error and cannot continue with the "
+"The app center has detected a fatal error and cannot continue with the "
 "installation. Please, restart your system. If the problem persists, please "
 "contact support."
 msgstr "Mais programas detectou um erro fatal e não pode continuar. Por favor, reinicie o sistema. Se o problema persistir, por favor entre em contato com o suporte."
@@ -270,82 +271,86 @@ msgstr "Nenhuma assinatura disponível para o programa '%s'"
 msgid "Application bundle '%s' could not be downloaded"
 msgstr "Não foi possível baixar o pacote de programas '%s'"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1238
+#: ../EosAppStore/lib/eos-app-list-model.c:1188
+msgid "No space available for installing the app"
+msgstr ""
+
+#: ../EosAppStore/lib/eos-app-list-model.c:1257
 #, c-format
 msgid "Application '%s' could not be installed"
 msgstr "Programa '%s' não pôde ser instalado "
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1245
+#: ../EosAppStore/lib/eos-app-list-model.c:1264
 #, c-format
 msgid "Application '%s' could not be installed. %s"
 msgstr "O programa '%s' não pôde ser instalado.  %s"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1270
+#: ../EosAppStore/lib/eos-app-list-model.c:1289
 #, c-format
 msgid "Application '%s' could not be removed"
 msgstr "Programa '%s' não pôde ser removido"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1277
+#: ../EosAppStore/lib/eos-app-list-model.c:1296
 #, c-format
 msgid "Application '%s' could not be removed. %s"
 msgstr "O programa '%s' não pode ser desentalado. %s "
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1301
-#: ../EosAppStore/lib/eos-app-list-model.c:1349
+#: ../EosAppStore/lib/eos-app-list-model.c:1320
+#: ../EosAppStore/lib/eos-app-list-model.c:1368
 msgid "You must be an administrator to install applications"
 msgstr "Você deve ser um administrador para instalar programas"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1313
-#: ../EosAppStore/lib/eos-app-list-model.c:1508
+#: ../EosAppStore/lib/eos-app-list-model.c:1332
+#: ../EosAppStore/lib/eos-app-list-model.c:1527
 msgid ""
-"The app store has detected a fatal error and cannot continue. Please, "
+"The app center has detected a fatal error and cannot continue. Please, "
 "restart your system. If the problem persists, please contact support."
 msgstr "Mais programas detectou um erro fatal e não pode continuar. Por favor, reinicie o sistema. Se o problema persistir, por favor entre em contato com o suporte."
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1496
-#: ../EosAppStore/lib/eos-app-list-model.c:1526
+#: ../EosAppStore/lib/eos-app-list-model.c:1515
+#: ../EosAppStore/lib/eos-app-list-model.c:1545
 msgid "You must be an administrator to remove applications"
 msgstr "Você deve ser um administrador para remover programas"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1659
-#: ../EosAppStore/lib/eos-app-list-model.c:1727
+#: ../EosAppStore/lib/eos-app-list-model.c:1678
+#: ../EosAppStore/lib/eos-app-list-model.c:1746
 #, c-format
 msgid "App %s not installable"
 msgstr "Não é possível instalar o programa %s "
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1671
+#: ../EosAppStore/lib/eos-app-list-model.c:1690
 #, c-format
 msgid "App %s already installed"
 msgstr "O programa %s já está instalado"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1738
+#: ../EosAppStore/lib/eos-app-list-model.c:1757
 #, c-format
 msgid "App %s is up to date"
 msgstr "O programa %s está atualizado"
 
-#: ../EosAppStore/lib/eos-app-list-model.c:1809
-#: ../EosAppStore/lib/eos-app-list-model.c:1841
+#: ../EosAppStore/lib/eos-app-list-model.c:1828
+#: ../EosAppStore/lib/eos-app-list-model.c:1860
 #, c-format
 msgid "App %s is not installed"
 msgstr " O programa %s não está instalado"
 
-#: ../EosAppStore/lib/eos-app-utils.c:879
+#: ../EosAppStore/lib/eos-app-utils.c:991
 msgid "Operation cancelled"
 msgstr "Operação cancelada"
 
-#: ../EosAppStore/lib/eos-app-utils.c:901
+#: ../EosAppStore/lib/eos-app-utils.c:1013
 msgid "Updates meta record did not contain expected structure"
 msgstr "O arquivo de atualização não contém a estrutura esperada"
 
-#: ../EosAppStore/lib/eos-app-utils.c:916
+#: ../EosAppStore/lib/eos-app-utils.c:1028
 msgid "Updates meta record did not contain expected attributes"
 msgstr "O arquivo de atualização não contém os atributos esperados"
 
-#: ../EosAppStore/lib/eos-app-utils.c:932
+#: ../EosAppStore/lib/eos-app-utils.c:1044
 msgid "Updates meta record did not contain valid monotonic_id attribute value"
 msgstr "O arquivo de atualização não contem um atributo monotonic_id válido."
 
-#: ../EosAppStore/lib/eos-app-utils.c:1744
+#: ../EosAppStore/lib/eos-app-utils.c:1856
 #, c-format
 msgid "Not enough space on device for downloading app"
 msgstr "O dispositivo não tem espaço suficiente para baixar o programa"


### PR DESCRIPTION
Touch only those strings that are user-facing or show up
as needing translations.  For now, the code still refers
to itself as the app store.

[endlessm/eos-shell#5310]
