### PR TITLE
app-info: don't use storage type to determine if it can be removed

### DIFF
--- a/EosAppStore/lib/eos-app-info.c
+++ b/EosAppStore/lib/eos-app-info.c
@@ -423,7 +423,11 @@ eos_app_info_is_updatable (const EosAppInfo *info)
 gboolean
 eos_app_info_is_removable (const EosAppInfo *info)
 {
-  return info->storage_type == EOS_STORAGE_TYPE_PRIMARY;
+  /* We can remove those applications that we have loaded
+   * from the installed directories - that is those that
+   * have info->info_filename set.
+   */
+  return info->info_filename != NULL;
 }
 
 EosAppCategory


### PR DESCRIPTION
Instead, mark as removable the applications for which we have an .info
file, i.e. those that we have installed in the primary and secondary
storages. That will exclude the core apps too.

[endlessm/eos-shell#5384]
