### PR TITLE
theme: Adjust borders for state buttons after the GTK upgrade, again

### DIFF
--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -266,8 +266,9 @@
     background: none;
 
     background-image: url("btn_install_normal_middle.png");
-    border-image: url("btn_install_normal_border.png") 0 17 0 17 / 0px 17px 0px 17px;
-    border-width: 0px 17px 0px 17px;
+    background-position: -2px;
+    border-image: url("btn_install_normal_border.png") 2 17 2 17 / 2px 17px 2px 17px;
+    border-width: 2px 17px 2px 17px;
 
     /* Setting padding to 0px gets the text 4px closer to each edge */
     padding-left: 0px;


### PR DESCRIPTION
Not doing the trick of shifting the background position a bit and
compensating that in the border works with "install", "update" and
"remove" buttons, but not with "cancel" ones.

[endlessm/eos-shell#5321]
