### PR TITLE
Fixed clearing of app store metadata

### DIFF
--- a/eos-reset-app-store
+++ b/eos-reset-app-store
@@ -51,7 +51,7 @@ sudo pkill eam
 
 if $CLEAR_CACHE; then
     echo Clearing the app manager cache
-    rm ~/.cache/com.endlessm.AppStore/updates.json
+    rm ~/.cache/com.endlessm.AppStore/updates*.json
 fi
 
 if $LAUNCH; then


### PR DESCRIPTION
With the new updates_meta.json, we also needed this in the
eos-reset-app-store to help testing but it wasn't included so now we
ensure that we remove both cache files.

[endlessm/eos-shell#5461]
