### PR TITLE
App Store: Increased dbus tool update timeout

### DIFF
--- a/tools/eas_dbus_tool.py
+++ b/tools/eas_dbus_tool.py
@@ -127,6 +127,9 @@ class UpdateEasDbusMethod(GenericEasDbusMethod):
     def __init__(self, params):
         super().__init__("update", "Update", params);
 
+        # Update can be a much longer operation
+        self.timeout = 20 * 60 * 1000;
+
     def _arg_handler(self, args):
         print('App ID: %s' % args.app_id)
         self.args = GLib.Variant('(s)', (args.app_id,))


### PR DESCRIPTION
Since the update may take a long time, we need to ensure that DBus
doesn't cut the cord on us - even though the app would probably update
fine in the background.

[endlessm/eos-shell#5051]
