### PR TITLE
folderFrame: disable keyboard navigation inside the GtkFlowBox

### DIFF
--- a/EosAppStore/folderFrame.js
+++ b/EosAppStore/folderFrame.js
@@ -220,7 +220,8 @@ const FolderIconGrid = new Lang.Class({
         this.parent({
             row_spacing: _FOLDER_GRID_SPACING,
             column_spacing: _FOLDER_GRID_SPACING,
-            border_width: _FOLDER_GRID_BORDER });
+            border_width: _FOLDER_GRID_BORDER,
+            selection_mode: Gtk.SelectionMode.NONE });
 
         this._folderModel = folderModel;
         this._iconList = this._folderModel.getIconList();


### PR DESCRIPTION
Letting the user navigate using the keyboard leads to some confusing and
broken behaviour in this view, which is meant to be used with the mouse,
and is also inconsistent with the other views in the AppStore, which do
not support this type of navigation anyway.

[endlessm/eos-shell#5479]
