### PR TITLE
appFrame: Always make sure to update the state after uninstalling

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -590,6 +590,8 @@ const AppListBoxRow = new Lang.Class({
                 else {
                     this._maybeNotify(_("'%s' was removed successfully").format(this.appTitle));
                 }
+
+                this._updateState();
             }));
         }
     },


### PR DESCRIPTION
Normally, the state will be signalled from the app list model, which is
updated from the Shell and Gio, but in certain circumstances, it's
possible to "beat the race" and have Shell and Gio both poke our
callbacks asynchronously before the transaction is complete. Always
update at the end of a transaction to guarantee that our state will be
consistent.

[endlessm/eos-shell#5318]
