### PR TITLE
App Store: Fixed filtering of apps by locale when app is not on desktop

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -278,11 +278,8 @@ get_localized_app_info (EosAppListModel *model,
       info = g_hash_table_lookup (model->apps, localized_id);
       g_free (localized_id);
 
-      /* Only return things that are installed or still on the system but not
-       * on the desktop
-       */
-      if (info &&
-          (eos_app_info_is_installed (info) || eos_app_info_is_removable (info)))
+      /* Only return things that are installed */
+      if (info && eos_app_info_is_installed (info))
           return info;
     }
 


### PR DESCRIPTION
Previously, we checked all locales only for the installed category but
now we check all locales for any category but only return ones that are
available on the system (installed or installed but not on desktop).

[endlessm/eos-shell#5509]
