### PR TITLE
Update to new config file format used by eos-app-manager

### DIFF
--- a/EosAppStore/Makefile-lib.am
+++ b/EosAppStore/Makefile-lib.am
@@ -11,6 +11,7 @@ eaprivate_cflags = \
 	$(EOS_APP_STORE_CFLAGS)
 
 eaprivate_source_h = \
+	lib/eam-config.h \
 	lib/eos-app-cell.h \
 	lib/eos-app-enums.h \
 	lib/eos-app-list-model.h \
@@ -26,6 +27,7 @@ eaprivate_source_h = \
 	lib/eos-vertical-stack-switcher.h
 
 eaprivate_source_c = \
+	lib/eam-config.c \
 	lib/eos-app-cell.c \
 	lib/eos-app-enums.c \
 	lib/eos-app-list-model.c \
@@ -77,7 +79,8 @@ BUILT_SOURCES += lib/eos-app-manager-service.c lib/eos-app-manager-service.h
 
 pkglib_LTLIBRARIES += libeaprivate-1.0.la
 
-introspection_sources = $(filter-out %private.h, $(eaprivate_source_h)) $(eaprivate_source_c)
+introspection_sources_nopriv = $(filter-out %private.h, $(eaprivate_source_h)) $(eaprivate_source_c)
+introspection_sources = $(filter lib/eos%, $(introspection_sources_nopriv))
 
 libeaprivate_1_0_la_LIBADD = $(EOS_APP_STORE_LIBS)
 libeaprivate_1_0_la_LDFLAGS = -avoid-version

--- a/EosAppStore/lib/eam-config.c
+++ b/EosAppStore/lib/eam-config.c
@@ -1,0 +1,307 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#include <string.h>
+#include <glib-object.h>
+
+#include "eam-config.h"
+#include "eos-app-log.h"
+
+#define EAM_CONFIG_DIRECTORIES  "Directories"
+#define EAM_CONFIG_DAEMON       "Daemon"
+#define EAM_CONFIG_REPOSITORY   "Repository"
+
+typedef struct {
+  /* Directories */
+  char *apps_root;
+  char *primary_storage;
+  char *secondary_storage;
+
+  /* Repository */
+  char *server_url;
+  char *api_version;
+  gboolean enable_delta_updates;
+} EamConfig;
+
+typedef struct {
+  const char *key_name;
+  const char *key_group;
+  gsize key_field;
+  GType key_type;
+  union {
+    int int_val;
+    const char *str_val;
+    gboolean bool_val;
+  } key_default;
+} EamConfigKey;
+
+static const EamConfigKey eam_config_keys[] = {
+  {
+    .key_name = "ApplicationsDir",
+    .key_group = EAM_CONFIG_DIRECTORIES,
+    .key_field = G_STRUCT_OFFSET (EamConfig, apps_root),
+    .key_type = G_TYPE_STRING,
+    .key_default.str_val = "/endless",
+  },
+  {
+    .key_name = "PrimaryStorage",
+    .key_group = EAM_CONFIG_DIRECTORIES,
+    .key_field = G_STRUCT_OFFSET (EamConfig, primary_storage),
+    .key_type = G_TYPE_STRING,
+    .key_default.str_val = LOCALSTATEDIR "/endless",
+  },
+  {
+    .key_name = "SecondaryStorage",
+    .key_group = EAM_CONFIG_DIRECTORIES,
+    .key_field = G_STRUCT_OFFSET (EamConfig, secondary_storage),
+    .key_type = G_TYPE_STRING,
+    .key_default.str_val = LOCALSTATEDIR "/endless-extra",
+  },
+  {
+    .key_name = "ServerUrl",
+    .key_group = EAM_CONFIG_REPOSITORY,
+    .key_field = G_STRUCT_OFFSET (EamConfig, server_url),
+    .key_type = G_TYPE_STRING,
+    .key_default.str_val = "http://appupdates.endlessm.com",
+  },
+  {
+    .key_name = "ApiVersion",
+    .key_group = EAM_CONFIG_REPOSITORY,
+    .key_field = G_STRUCT_OFFSET (EamConfig, api_version),
+    .key_type = G_TYPE_STRING,
+    .key_default.str_val = "v1",
+  },
+  {
+    .key_name = "EnableDeltaUpdates",
+    .key_group = EAM_CONFIG_REPOSITORY,
+    .key_field = G_STRUCT_OFFSET (EamConfig, enable_delta_updates),
+    .key_type = G_TYPE_BOOLEAN,
+    .key_default.bool_val = TRUE,
+  },
+};
+
+static inline void
+eam_config_set_key_internal (const EamConfigKey *key,
+                             EamConfig          *config,
+                             GKeyFile           *keyfile)
+{
+  g_autoptr(GError) error = NULL;
+  g_autofree char *str_value = NULL;
+  int int_value = 0;
+  gboolean bool_value = FALSE;
+  gpointer field_p = G_STRUCT_MEMBER_P (config, key->key_field);
+
+  switch (key->key_type) {
+    case G_TYPE_STRING:
+      str_value = g_key_file_get_string (keyfile, key->key_group, key->key_name, &error);
+      if (error == NULL)
+        (* (gpointer *) field_p) = g_strdup (str_value);
+      else
+        (* (gpointer *) field_p) = g_strdup (key->key_default.str_val);
+      break;
+
+    case G_TYPE_INT:
+      int_value = g_key_file_get_integer (keyfile, key->key_group, key->key_name, &error);
+      if (error == NULL)
+        (* (guint *) field_p) = int_value;
+      else
+        (* (guint *) field_p) = key->key_default.int_val;
+      break;
+
+    case G_TYPE_BOOLEAN:
+      bool_value = g_key_file_get_boolean (keyfile, key->key_group, key->key_name, &error);
+      if (error == NULL)
+        (* (gboolean *) field_p) = bool_value;
+      else
+        (* (gboolean *) field_p) = key->key_default.bool_val;
+      break;
+
+    default:
+      g_assert_not_reached ();
+  }
+
+  if (error != NULL)
+    eos_app_log_error_message ("Unable to read configuration key '%s': %s",
+                               key->key_name,
+                               error->message);
+}
+
+static EamConfig *
+eam_config_get (void)
+{
+  static volatile gpointer eam_config;
+
+  if (g_once_init_enter (&eam_config)) {
+    const char *config_env = g_getenv ("EAM_CONFIG_FILE");
+    if (config_env == NULL)
+      config_env = SYSCONFDIR "/eos-app-manager/eos-app-manager.ini";
+
+    EamConfig *config = g_new (EamConfig, 1);
+
+    g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+    g_autoptr(GError) error = NULL;
+    g_key_file_load_from_file (keyfile, config_env, 0, &error);
+
+    if (error != NULL)
+      eos_app_log_error_message ("Unable to load configuration from '%s': %s",
+                                 config_env,
+                                 error->message);
+
+    for (int i = 0; i < G_N_ELEMENTS (eam_config_keys); i++) {
+      const EamConfigKey *key = &eam_config_keys[i];
+
+      eam_config_set_key_internal (key, config, keyfile);
+    }
+
+    g_once_init_leave (&eam_config, config);
+  }
+
+  return eam_config;
+}
+
+gboolean
+eam_config_set_key (const char *key,
+                    const char *value)
+{
+  EamConfig *config = eam_config_get ();
+
+  const char *config_env = g_getenv ("EAM_CONFIG_FILE");
+  if (config_env == NULL)
+    config_env = SYSCONFDIR "/eos-app-manager/eos-app-manager.ini";
+
+  g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+  g_autoptr(GError) error = NULL;
+  g_key_file_load_from_file (keyfile, config_env, G_KEY_FILE_KEEP_COMMENTS, &error);
+
+  if (error != NULL) {
+    eos_app_log_error_message ("Unable to load configuration from '%s': %s",
+                               config_env,
+                               error->message);
+    return FALSE;
+  }
+
+  for (int i = 0; i < G_N_ELEMENTS (eam_config_keys); i++) {
+    const EamConfigKey *config_key = &eam_config_keys[i];
+
+    if (strcmp (key, config_key->key_name) == 0) {
+      g_key_file_set_value (keyfile, config_key->key_group, config_key->key_name, value);
+      g_key_file_save_to_file (keyfile, config_env, &error);
+      if (error != NULL) {
+        eos_app_log_error_message ("Unable to save configuration to '%s': %s",
+                                   config_env,
+                                   error->message);
+        return FALSE;
+      }
+
+      eam_config_set_key_internal (config_key, config, keyfile);
+      return TRUE;
+    }
+  }
+
+  /* Key wasn't found */
+  eos_app_log_error_message ("Unknown configuration key '%s'", key);
+  return FALSE;
+}
+
+gboolean
+eam_config_reset_key (const char *key)
+{
+  EamConfig *config = eam_config_get ();
+
+  const char *config_env = g_getenv ("EAM_CONFIG_FILE");
+  if (config_env == NULL)
+    config_env = SYSCONFDIR "/eos-app-manager/eos-app-manager.ini";
+
+  g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+  g_autoptr(GError) error = NULL;
+  g_key_file_load_from_file (keyfile, config_env, G_KEY_FILE_KEEP_COMMENTS, &error);
+
+  if (error != NULL) {
+    eos_app_log_error_message ("Unable to load configuration from '%s': %s",
+                               config_env,
+                               error->message);
+    return FALSE;
+  }
+
+  for (int i = 0; i < G_N_ELEMENTS (eam_config_keys); i++) {
+    const EamConfigKey *config_key = &eam_config_keys[i];
+
+    if (strcmp (key, config_key->key_name) == 0) {
+      switch (config_key->key_type) {
+        case G_TYPE_STRING:
+          g_key_file_set_string (keyfile,
+                                 config_key->key_group,
+                                 config_key->key_name,
+                                 config_key->key_default.str_val);
+          break;
+
+        case G_TYPE_INT:
+          g_key_file_set_integer (keyfile,
+                                  config_key->key_group,
+                                  config_key->key_name,
+                                  config_key->key_default.int_val);
+          break;
+
+        case G_TYPE_BOOLEAN:
+          g_key_file_set_boolean (keyfile,
+                                  config_key->key_group,
+                                  config_key->key_name,
+                                  config_key->key_default.bool_val);
+          break;
+
+        default:
+          g_assert_not_reached ();
+      }
+
+      g_key_file_save_to_file (keyfile, config_env, &error);
+      if (error != NULL) {
+        eos_app_log_error_message ("Unable to save configuration to '%s': %s",
+                                   config_env,
+                                   error->message);
+        return FALSE;
+      }
+
+      eam_config_set_key_internal (config_key, config, keyfile);
+      return TRUE;
+    }
+  }
+
+  /* Key wasn't found */
+  eos_app_log_error_message ("Unknown configuration key '%s'", key);
+  return FALSE;
+}
+
+const char *
+eam_config_get_applications_dir (void)
+{
+  return eam_config_get ()->apps_root;
+}
+
+const char *
+eam_config_get_primary_storage (void)
+{
+  return eam_config_get ()->primary_storage;
+}
+
+const char *
+eam_config_get_secondary_storage (void)
+{
+  return eam_config_get ()->secondary_storage;
+}
+
+const char *
+eam_config_get_server_url (void)
+{
+  return eam_config_get ()->server_url;
+}
+
+const char *
+eam_config_get_api_version (void)
+{
+  return eam_config_get ()->api_version;
+}
+
+gboolean
+eam_config_get_enable_delta_updates (void)
+{
+  return eam_config_get ()->enable_delta_updates;
+}

--- a/EosAppStore/lib/eam-config.h
+++ b/EosAppStore/lib/eam-config.h
@@ -1,0 +1,23 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EAM_CONFIG_H
+#define EAM_CONFIG_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+const char *    eam_config_get_applications_dir         (void);
+const char *    eam_config_get_primary_storage          (void);
+const char *    eam_config_get_secondary_storage        (void);
+const char *    eam_config_get_server_url               (void);
+const char *    eam_config_get_api_version              (void);
+gboolean        eam_config_get_enable_delta_updates     (void);
+
+gboolean        eam_config_set_key                      (const char *key,
+                                                         const char *value);
+gboolean        eam_config_reset_key                    (const char *key);
+
+G_END_DECLS
+
+#endif /* EAM_CONFIG_H */

--- a/EosAppStore/lib/eos-app-info.c
+++ b/EosAppStore/lib/eos-app-info.c
@@ -7,6 +7,7 @@
 #include "eos-app-log.h"
 #include "eos-app-utils.h"
 #include "eos-flexy-grid.h"
+#include "eam-config.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -664,10 +665,10 @@ EosStorageType
 eos_app_info_get_install_storage_type (const EosAppInfo *info)
 {
   if (eos_has_secondary_storage () &&
-      eos_app_info_get_has_sufficient_install_space (info, eos_get_secondary_storage ()))
+      eos_app_info_get_has_sufficient_install_space (info, eam_config_get_secondary_storage ()))
     return EOS_STORAGE_TYPE_SECONDARY;
 
-  if (eos_app_info_get_has_sufficient_install_space (info,  eos_get_primary_storage ()))
+  if (eos_app_info_get_has_sufficient_install_space (info,  eam_config_get_primary_storage ()))
     return EOS_STORAGE_TYPE_PRIMARY;
 
   return EOS_STORAGE_TYPE_UNKNOWN;

--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -10,6 +10,7 @@
 #include "eos-app-utils.h"
 #include "eos-downloader.h"
 #include "eos-net-utils-private.h"
+#include "eam-config.h"
 
 #include <time.h>
 #include <sys/types.h>
@@ -1075,7 +1076,7 @@ install_latest_app_version (EosAppListModel *self,
    */
   EosAppManager *proxy = get_eam_dbus_proxy (self);
   if (proxy == NULL ||
-      !g_file_test (eos_get_bundles_dir (), G_FILE_TEST_EXISTS))
+      !g_file_test (eam_config_get_applications_dir (), G_FILE_TEST_EXISTS))
     {
       external_message = _("The app center has detected a fatal error and "
                            "cannot continue. Please, "
@@ -1189,7 +1190,7 @@ update_app_from_manager (EosAppListModel *self,
 {
   GError *error = NULL;
   gboolean retval = FALSE;
-  gboolean allow_deltas = eos_use_delta_updates ();
+  gboolean allow_deltas = eam_config_get_enable_delta_updates ();
   const char *desktop_id = eos_app_info_get_desktop_id (info);
 
   eos_app_log_info_message ("Attempting to update '%s' (deltas allowed: %s)",
@@ -1269,7 +1270,7 @@ remove_app_from_manager (EosAppListModel *self,
    */
   EosAppManager *proxy = get_eam_dbus_proxy (self);
   if (proxy == NULL ||
-      !g_file_test (eos_get_bundles_dir (), G_FILE_TEST_EXISTS))
+      !g_file_test (eam_config_get_applications_dir (), G_FILE_TEST_EXISTS))
     {
       external_message = _("The app center has detected a fatal error and "
                            "cannot continue. Please, "

--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -6,6 +6,7 @@
 
 #include "eos-app-log.h"
 #include "eos-link-info.h"
+#include "eam-config.h"
 
 #include <locale.h>
 #include <glib/gi18n.h>
@@ -181,48 +182,13 @@ eos_get_cache_dir (void)
   return download_url;
 }
 
-const char *
-eos_get_bundles_dir (void)
-{
-  static char *apps_dir;
-
-  if (g_once_init_enter (&apps_dir))
-    {
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        tmp = g_key_file_get_string (keyfile, "Directories", "ApplicationsDir", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-          tmp = g_strdup (APP_DIR_DEFAULT);
-        }
-
-      eos_app_log_info_message ("Bundles dir: %s", tmp);
-
-      g_free (path);
-      g_key_file_free (keyfile);
-
-      g_once_init_leave (&apps_dir, tmp);
-    }
-
-  return apps_dir;
-}
-
 gboolean
 eos_has_secondary_storage (void)
 {
   const char *primary_storage, *secondary_storage;
 
-  primary_storage = eos_get_primary_storage ();
-  secondary_storage = eos_get_secondary_storage ();
+  primary_storage = eam_config_get_primary_storage ();
+  secondary_storage = eam_config_get_secondary_storage ();
 
   /* The secondary storage path does not exist */
   struct stat secondary_statbuf;
@@ -241,178 +207,6 @@ eos_has_secondary_storage (void)
    * device than the primary.
    */
   return primary_statbuf.st_dev != secondary_statbuf.st_dev;
-}
-
-const char *
-eos_get_primary_storage (void)
-{
-  static char *apps_dir;
-
-  if (g_once_init_enter (&apps_dir))
-    {
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        tmp = g_key_file_get_string (keyfile, "Directories", "PrimaryStorage", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-          tmp = g_strdup (APP_DIR_DEFAULT);
-        }
-
-      eos_app_log_info_message ("Primary storage dir: %s", tmp);
-
-      g_free (path);
-      g_key_file_free (keyfile);
-
-      g_once_init_leave (&apps_dir, tmp);
-    }
-
-  return apps_dir;
-}
-
-const char *
-eos_get_secondary_storage (void)
-{
-  static char *apps_dir;
-
-  if (g_once_init_enter (&apps_dir))
-    {
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        tmp = g_key_file_get_string (keyfile, "Directories", "SecondaryStorage", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-          tmp = g_strdup (APP_DIR_DEFAULT);
-        }
-
-      eos_app_log_info_message ("Secondary storage dir: %s", tmp);
-
-      g_free (path);
-      g_key_file_free (keyfile);
-
-      g_once_init_leave (&apps_dir, tmp);
-    }
-
-  return apps_dir;
-}
-
-gboolean
-eos_use_delta_updates (void)
-{
-  static char *deltaupdates;
-
-  if (g_once_init_enter (&deltaupdates))
-    {
-      gboolean val = FALSE;
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        val = g_key_file_get_boolean (keyfile, "Repository", "EnableDeltaUpdates", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-        }
-
-      eos_app_log_info_message ("Use delta updates: %s", val ? "yes" : "no");
-
-      /* Need this trick because g_once_init_leave() does not accept 0 */
-      tmp = val ? g_strdup ("true") : g_strdup ("false");
-
-      g_free (path);
-      g_key_file_free (keyfile);
-
-      g_once_init_leave (&deltaupdates, tmp);
-    }
-
-  return g_strcmp0 (deltaupdates, "true") == 0;
-}
-
-const char *
-eos_get_app_server_url (void)
-{
-  static char *server_url;
-
-  if (g_once_init_enter (&server_url))
-    {
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        tmp = g_key_file_get_string (keyfile, "Repository", "ServerUrl", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-          tmp = g_strdup ("http://appupdates.endlessm.com/");
-        }
-
-      eos_app_log_info_message ("Server address: %s", tmp);
-
-      g_once_init_leave (&server_url, tmp);
-    }
-
-  return server_url;
-}
-
-static const char *
-eos_get_app_server_api (void)
-{
-  static char *server_api;
-
-  if (g_once_init_enter (&server_api))
-    {
-      char *tmp;
-
-      GKeyFile *keyfile = g_key_file_new ();
-      char *path = g_build_filename (SYSCONFDIR, "eos-app-manager", "eam-default.cfg", NULL);
-      GError *error = NULL;
-      g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, &error);
-      if (error == NULL)
-        tmp = g_key_file_get_string (keyfile, "Repository", "ApiVersion", &error);
-
-      if (error != NULL)
-        {
-          eos_app_log_error_message ("Unable to load configuration: %s",
-                                     error->message);
-          g_error_free (error);
-          tmp = g_strdup ("v1");
-        }
-
-      eos_app_log_info_message ("Server API version: %s", tmp);
-
-      g_once_init_leave (&server_api, tmp);
-    }
-
-  return server_api;
 }
 
 /*
@@ -878,9 +672,9 @@ eos_get_updates_file (void)
 char *
 eos_get_all_updates_uri (void)
 {
-  return g_strconcat (eos_get_app_server_url (),
+  return g_strconcat (eam_config_get_server_url (),
                       "/api/",
-                      eos_get_app_server_api (),
+                      eam_config_get_api_version (),
                       "/updates/",
                       get_os_version (),
                       "?arch=", get_os_arch (),
@@ -897,7 +691,7 @@ eos_get_updates_meta_record_file (void)
 char *
 eos_get_updates_meta_record_uri (void)
 {
-  return g_strconcat (eos_get_app_server_url (),
+  return g_strconcat (eam_config_get_server_url (),
                       "/api/v1/meta_records",
                       "?type=updates",
                       NULL);
@@ -1010,12 +804,12 @@ eos_app_load_installed_apps (GHashTable *app_info,
 
   eos_app_log_info_message ("Reloading installed apps");
 
-  const char *storage = eos_get_primary_storage ();
+  const char *storage = eam_config_get_primary_storage ();
   retval = eos_app_load_installed_apps_for_prefix (app_info, storage, cancellable);
 
   if (eos_has_secondary_storage ())
     {
-      storage = eos_get_secondary_storage ();
+      storage = eam_config_get_secondary_storage ();
       retval |= eos_app_load_installed_apps_for_prefix (app_info, storage, cancellable);
     }
 
@@ -1283,7 +1077,7 @@ eos_app_load_available_apps (GHashTable *app_info,
       const gboolean is_diff = json_object_get_boolean_member (obj, "isDiff");
       const char *code_version = json_object_get_string_member (obj, "codeVersion");
 
-      if (is_diff && !eos_use_delta_updates ())
+      if (is_diff && !eam_config_get_enable_delta_updates ())
         {
           eos_app_log_debug_message ("Deltas disabled. Ignoring diff for %s", app_id);
 

--- a/EosAppStore/lib/eos-app-utils.h
+++ b/EosAppStore/lib/eos-app-utils.h
@@ -38,16 +38,10 @@ char *  eos_get_updates_file (void);
 char *  eos_get_updates_meta_record_uri (void);
 char *  eos_get_updates_meta_record_file (void);
 
-const char *eos_get_bundles_dir (void);
 const char *eos_get_cache_dir (void);
 const char *eos_get_bundle_download_dir (void);
 void        eos_clear_bundle_download_dir (void);
-const char *eos_get_app_server_url (void);
-const char *eos_get_primary_storage (void);
-const char *eos_get_secondary_storage (void);
 gboolean    eos_has_secondary_storage (void);
-
-gboolean eos_use_delta_updates (void);
 
 gboolean eos_app_load_installed_apps      (GHashTable    *app_info,
                                            GCancellable  *cancellable);


### PR DESCRIPTION
eos-app-manager changed config file locations from eam-default.cfg to
eos-app-manager.ini. Instead of cargo-culting a bunch of find-replaces
to keep this in sync, just copy over and hack up the eam-config file
directly, so it will be easier to sync up in the future.

[endlessm/eos-shell#5568]
