### PR TITLE
downloader: Fetch the old monotonic ID before downloading the meta file

### DIFF
--- a/EosAppStore/lib/eos-downloader.c
+++ b/EosAppStore/lib/eos-downloader.c
@@ -210,6 +210,7 @@ check_is_app_list_current (SoupSession *soup_session,
   GError *error = NULL;
 
   eos_app_log_info_message ("Checking if app list update is needed");
+  old_monotonic_id = get_local_updates_monotonic_id ();
 
   eos_app_log_info_message ("Downloading updates meta record from: %s", url);
   if (!eos_net_utils_download_file (soup_session,
@@ -238,7 +239,6 @@ check_is_app_list_current (SoupSession *soup_session,
       goto out;
     }
 
-  old_monotonic_id = get_local_updates_monotonic_id ();
   eos_app_log_info_message ("Comparing monotonic update ID."
                             " Old: %" G_GINT64_FORMAT ","
                             " New: %" G_GINT64_FORMAT ".",


### PR DESCRIPTION
If we fetch the file and then read the monotonic ID from it, we'll load
the monotonic ID from the newly fetched file, and thus never go and
download a new set of application updates.

[endlessm/eos-shell#5594]
