### PR TITLE
css: don't set a box-shadow on add folder button

### DIFF
--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -703,6 +703,7 @@
     background-repeat: no-repeat;
     background-image: url("btn_add-folder_normal.png");
     background-color: transparent;
+    box-shadow: none;
 }
 
 .folder-bubble .button:hover {


### PR DESCRIPTION
It will look glitchy, since we use an image asset here.

[endlessm/eos-shell#5515]
