### PR TITLE
eos-app-utils: add "games" dir to the reserved array

### DIFF
--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -737,7 +737,7 @@ static gboolean
 is_app_id (const char *appid)
 {
   static const char alsoallowed[] = "_-+.";
-  static const char *reserveddirs[] = { "bin", "share", "lost+found", "xdg", };
+  static const char *reserveddirs[] = { "bin", "games", "share", "lost+found", "xdg", };
 
   if (!appid || appid[0] == '\0')
     return FALSE;


### PR DESCRIPTION
So that we don't try to parse it as an app ID.

[endlessm/eos-shell#5637]
