### PR TITLE
App Store: Fixes logic bug during server data parsing

### DIFF
--- a/EosAppStore/lib/eos-app-utils.c
+++ b/EosAppStore/lib/eos-app-utils.c
@@ -964,7 +964,7 @@ remove_records_version_lte (GList *deltas,
         {
           eos_app_log_debug_message (" - Deleting delta %s -> %s", from_version,
                                      code_version);
-          new_list = g_list_delete_link (deltas, iterator);
+          new_list = g_list_delete_link (new_list, iterator);
           json_object_unref (obj);
         }
     }


### PR DESCRIPTION
Old code used delete_link on the records which would free the object on
its own and we would then unref the object ourselves which would in some
edge cases cause a double-unref which we now don't do.

[endlessm/eos-shell#5672]
