### PR TITLE
App Store: Fixed minor deprecation warning in a ui file

### DIFF
--- a/data/eos-app-store-app-installed-box.ui
+++ b/data/eos-app-store-app-installed-box.ui
@@ -21,7 +21,7 @@
               <object class="GtkImage" id="_appIcon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="stock">gtk-about</property>
+                <property name="icon-name">gtk-about</property>
                 <property name="use_fallback">True</property>
                 <property name="icon_size">6</property>
                 <property name="margin_start">7</property>


### PR DESCRIPTION
stock is deprecated for GtkIcon so it got changed to icon-name

[endlessm/eos-shell#5747]
