### PR TITLE
Make size computation asynchronous

### DIFF
--- a/EosAppStore/lib/eos-app-info-private.h
+++ b/EosAppStore/lib/eos-app-info-private.h
@@ -39,6 +39,8 @@ struct _EosAppInfo
   gint64 info_installed_size;
   gint64 server_installed_size;
 
+  GCancellable *size_computation_cancellable;
+
   char *square_img;
   char *featured_img;
   char *icon_name;
@@ -61,6 +63,7 @@ struct _EosAppInfo
   guint is_installed : 1;
   guint has_launcher : 1;
   guint has_override : 1;
+  guint installed_size_computed : 1;
 };
 
 struct _EosAppInfoClass {

--- a/EosAppStore/lib/eos-app-info.h
+++ b/EosAppStore/lib/eos-app-info.h
@@ -53,6 +53,7 @@ char **         eos_app_info_get_screenshots            (const EosAppInfo *info)
 
 gboolean        eos_app_info_is_installable             (const EosAppInfo *info);
 gboolean        eos_app_info_is_installed               (const EosAppInfo *info);
+gboolean        eos_app_info_is_store_installed         (const EosAppInfo *info);
 gboolean        eos_app_info_is_available               (const EosAppInfo *info);
 gboolean        eos_app_info_is_updatable               (const EosAppInfo *info);
 gboolean        eos_app_info_is_removable               (const EosAppInfo *info);


### PR DESCRIPTION
Under some circumstances, we will need to compute the size of an
application directly from the directory on the file system.
Make sure that computation is done asynchronously, or it could take a
long time.

[endlessm/eos-shell#5819]
