### PR TITLE
Persist updating state

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -43,9 +43,9 @@ const AppBaseBox = new Lang.Class({
         this._model = app.appListModel;
         this._appInfo = appInfo;
 
-        this._networkChangeId = this._model.connect('network-changed', Lang.bind(this, this._updateState));
+        this._networkChangeId = this._model.connect('network-changed', Lang.bind(this, this._syncState));
         this._progressId = this._model.connect('download-progress', Lang.bind(this, this._onDownloadProgress));
-        this._stateChangedId = this._appInfo.connect('notify::state', Lang.bind(this, this._updateState));
+        this._stateChangedId = this._appInfo.connect('notify::state', Lang.bind(this, this._syncState));
         this._windowHideId = mainWindow.connect('hide', Lang.bind(this, this._destroyPendingDialogs));
 
         this._removeDialog = null;
@@ -106,7 +106,7 @@ const AppBaseBox = new Lang.Class({
         // to be overridden
     },
 
-    _updateState: function() {
+    _syncState: function() {
         // to be overridden
     },
 
@@ -183,7 +183,7 @@ const AppBaseBox = new Lang.Class({
                 app.maybeNotifyUser(_("'%s' was removed successfully").format(this.appTitle));
             }
 
-            this._updateState();
+            this._syncState();
 
             if (callback) {
                 callback(error);
@@ -206,7 +206,7 @@ const AppBaseBox = new Lang.Class({
                 app.maybeNotifyUser(_("'%s' was updated successfully").format(this.appTitle));
             }
 
-            this._updateState();
+            this._syncState();
 
             if (callback) {
                 callback(error);
@@ -229,7 +229,7 @@ const AppBaseBox = new Lang.Class({
                 app.maybeNotifyUser(_("'%s' was installed successfully").format(this.appTitle));
             }
 
-            this._updateState();
+            this._syncState();
 
             if (!error) {
                 let appWindow = Gio.Application.get_default().mainWindow;
@@ -304,10 +304,10 @@ const AppInfoBox = new Lang.Class({
         this._mainBox.reorder_child(separator, 0);
         this._mainBox.show();
 
-        this._updateState();
+        this._syncState();
     },
 
-    _updateState: function() {
+    _syncState: function() {
         this.appState = this.appInfo.get_state();
     },
 

--- a/EosAppStore/appInstalledBox.js
+++ b/EosAppStore/appInstalledBox.js
@@ -54,7 +54,7 @@ const AppInstalledBox = new Lang.Class({
         this.setImageFrame(this._removeButton, this._removeButtonImage);
         this.setImageFrame(this._updateButton, this._updateButtonImage);
 
-        this._updateState();
+        this._syncState();
     },
 
     _onDestroy: function() {
@@ -103,7 +103,7 @@ const AppInstalledBox = new Lang.Class({
         }
     },
 
-    _updateState: function() {
+    _syncState: function() {
         // Hide all controls, and show only what's needed
         this._updateButton.hide();
         this._removeButton.hide();
@@ -118,22 +118,20 @@ const AppInstalledBox = new Lang.Class({
         if (this.appInfo.is_removable()) {
             this._removeButton.show();
         }
+
+        this._syncUpdateState();
     },
 
-    _downloadProgress: function(progress, current, total) {
-        this._updateProgressBar.fraction = progress;
-    },
+    _syncUpdateState: function() {
+        if (this.appInfo.is_updating()) {
+            this._appIcon.opacity = UPDATING_OPACITY;
+            this._nameText.opacity = UPDATING_OPACITY;
+            this._categoryText.opacity = UPDATING_OPACITY;
 
-    _onUpdateButtonClicked: function() {
-        this._appIcon.opacity = UPDATING_OPACITY;
-        this._nameText.opacity = UPDATING_OPACITY;
-        this._categoryText.opacity = UPDATING_OPACITY;
-
-        this._updateProgressBar.show();
-        this._updateSpinner.start();
-        this._controlsStack.visible_child_name = 'spinner';
-
-        this.doUpdate(Lang.bind(this, function() {
+            this._updateProgressBar.show();
+            this._updateSpinner.start();
+            this._controlsStack.visible_child_name = 'spinner';
+        } else {
             this._appIcon.opacity = NORMAL_OPACITY;
             this._nameText.opacity = NORMAL_OPACITY;
             this._categoryText.opacity = NORMAL_OPACITY;
@@ -141,9 +139,19 @@ const AppInstalledBox = new Lang.Class({
             this._updateProgressBar.hide();
             this._updateSpinner.stop();
             this._controlsStack.visible_child_name = 'controls';
+        }
+    },
 
-            this._updateState();
+    _downloadProgress: function(progress, current, total) {
+        this._updateProgressBar.fraction = progress;
+    },
+
+    _onUpdateButtonClicked: function() {
+        this.doUpdate(Lang.bind(this, function() {
+            this._syncState();
         }));
+
+        this._syncState();
     },
 
     _onRemoveButtonClicked: function() {

--- a/EosAppStore/lib/eos-app-info-private.h
+++ b/EosAppStore/lib/eos-app-info-private.h
@@ -64,6 +64,7 @@ struct _EosAppInfo
   guint has_launcher : 1;
   guint has_override : 1;
   guint installed_size_computed : 1;
+  guint is_updating : 1;
 };
 
 struct _EosAppInfoClass {

--- a/EosAppStore/lib/eos-app-info.c
+++ b/EosAppStore/lib/eos-app-info.c
@@ -562,6 +562,12 @@ eos_app_info_is_updatable (const EosAppInfo *info)
 }
 
 gboolean
+eos_app_info_is_updating (const EosAppInfo *info)
+{
+  return info->is_updating;
+}
+
+gboolean
 eos_app_info_is_removable (const EosAppInfo *info)
 {
   /* We can remove those applications that we have installed */
@@ -1150,4 +1156,12 @@ eos_app_info_update_from_content (EosAppInfo *info,
     info->n_screenshots = 0;
 
   return TRUE;
+}
+
+/*< private >*/
+void
+eos_app_info_set_is_updating (EosAppInfo *info,
+                              gboolean is_updating)
+{
+  info->is_updating = is_updating;
 }

--- a/EosAppStore/lib/eos-app-info.h
+++ b/EosAppStore/lib/eos-app-info.h
@@ -56,6 +56,7 @@ gboolean        eos_app_info_is_installed               (const EosAppInfo *info)
 gboolean        eos_app_info_is_store_installed         (const EosAppInfo *info);
 gboolean        eos_app_info_is_available               (const EosAppInfo *info);
 gboolean        eos_app_info_is_updatable               (const EosAppInfo *info);
+gboolean        eos_app_info_is_updating                (const EosAppInfo *info);
 gboolean        eos_app_info_is_removable               (const EosAppInfo *info);
 
 gboolean        eos_app_info_get_has_launcher           (const EosAppInfo *info);
@@ -91,6 +92,9 @@ void            eos_app_info_set_has_launcher           (EosAppInfo *info,
 G_GNUC_INTERNAL
 void            eos_app_info_set_is_installed           (EosAppInfo *info,
                                                          gboolean    is_installed);
+G_GNUC_INTERNAL
+void            eos_app_info_set_is_updating            (EosAppInfo *info,
+                                                         gboolean    is_updating);
 
 #endif
 

--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1525,6 +1525,8 @@ eos_app_list_model_update_app_async (EosAppListModel *model,
       return;
     }
 
+  eos_app_info_set_is_updating (info, TRUE);
+
   g_task_set_task_data (task, g_object_ref (info), g_object_unref);
   g_task_run_in_thread (task, update_app_thread_func);
   g_object_unref (task);
@@ -1535,7 +1537,12 @@ eos_app_list_model_update_app_finish (EosAppListModel *model,
                                       GAsyncResult *result,
                                       GError **error)
 {
-  return g_task_propagate_boolean (G_TASK (result), error);
+  GTask *task = G_TASK (result);
+  EosAppInfo *info = g_task_get_task_data (task);
+
+  eos_app_info_set_is_updating (info, FALSE);
+
+  return g_task_propagate_boolean (task, error);
 }
 
 static void


### PR DESCRIPTION
While an update is in progress, we set a flag on EosAppInfo, so that the
UI view can recreate a consistent state in case the widgets are
invalidated.

[endlessm/eos-shell#5820]
