### PR TITLE
App Store: Fixed sizing issues of installed page on low resolutions

### DIFF
--- a/data/eos-app-store-app-installed-box.ui
+++ b/data/eos-app-store-app-installed-box.ui
@@ -49,7 +49,7 @@
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">APPLICATION NAME</property>
                     <property name="ellipsize">end</property>
-                    <property name="width_chars">38</property>
+                    <property name="width_chars">20</property>
                     <property name="max_width_chars">40</property>
                     <property name="lines">1</property>
                     <property name="xalign">0</property>
@@ -70,7 +70,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">APPLICATION CATEGORY</property>
-                    <property name="width_chars">40</property>
+                    <property name="width_chars">20</property>
                     <property name="max_width_chars">40</property>
                     <property name="lines">1</property>
                     <property name="xalign">0</property>


### PR DESCRIPTION
Min size of 40 was pushing the category column off screen so by reducing
it we now have the proper layout.

[endlessm/eos-shell#5829]
