### PR TITLE
net-utils: do not trigger retry logic when disk is full

### DIFF
--- a/EosAppStore/lib/eos-net-utils.c
+++ b/EosAppStore/lib/eos-net-utils.c
@@ -596,6 +596,14 @@ eos_net_utils_download_file_with_retry (SoupSession            *session,
       if (download_success)
         break;
 
+      /* If we're out of disk space, don't bother retrying */
+      if (g_error_matches (error, EOS_APP_STORE_ERROR,
+                           EOS_APP_STORE_ERROR_DISK_FULL))
+        {
+          g_propagate_error (error_out, error);
+          break;
+        }
+
       /* If we got canceled, also bail */
       if (g_cancellable_is_cancelled (cancellable))
         {


### PR DESCRIPTION
We're goign to fail again otherwise.

[endlessm/eos-shell#5831]
