### PR TITLE
Fix add to desktop

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -590,7 +590,7 @@ const AppInfoBox = new Lang.Class({
                 }
                 // or we add a launcher on the desktop
                 else {
-                    this._addToDesktop();
+                    this.doInstall();
                 }
                 break;
         }


### PR DESCRIPTION
The _addToDesktop function was removed in favor of calling doInstall
directly, but one instance had been replaced yet.

[endlessm/eos-shell#5898]
