### PR TITLE
App Store: Made remove button not depend on launcher visibility

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -460,9 +460,7 @@ const AppInfoBox = new Lang.Class({
 
                 this._installButton.show();
 
-                // Only apps that don't have a launcher can be
-                // removed from the system
-                if (!this.appInfo.get_has_launcher() && this.appInfo.is_removable()) {
+                if (this.appInfo.is_removable()) {
                     this._removeButton.show();
                 }
                 break;


### PR DESCRIPTION
Since we can now remove apps regardless of if the laucher is on the
desktop or not, the button to remove an app from the system is always
shown (if the app is removable)

[endlessm/eos-shell#5884]
