### PR TITLE
CSS: fix RTL padding

### DIFF
--- a/data/eos-app-store.css
+++ b/data/eos-app-store.css
@@ -120,6 +120,7 @@
 .web-frame:dir(rtl),
 .folder-frame:dir(rtl) {
     padding-left: 15px;
+    padding-right: 0px;
 }
 
 .app-frame .app-scrolledwindow {


### PR DESCRIPTION
In RTL languages such as Arabic, we inherit from the LTR properties,
so we have to explicitly disable the padding-right that is
no longer relevant.

[endlessm/eos-shell#5914]
