### PR TITLE
appInstalledBox: use all available space for the "System App" label

### DIFF
--- a/EosAppStore/appInstalledBox.js
+++ b/EosAppStore/appInstalledBox.js
@@ -108,8 +108,6 @@ const AppInstalledBox = new Lang.Class({
                    and can be placed before or after the abbreviation */
                 this._sizeText.label = _("%s MB").format(sizeInMb.toFixed(1));
             }
-        } else {
-                this._sizeText.label = _("System App");
         }
     },
 
@@ -140,14 +138,21 @@ const AppInstalledBox = new Lang.Class({
             this._updateProgressBar.show();
             this._updateSpinner.start();
             this._controlsStack.visible_child_name = 'spinner';
-        } else {
-            this._appIcon.opacity = NORMAL_OPACITY;
-            this._nameText.opacity = NORMAL_OPACITY;
-            this._categoryText.opacity = NORMAL_OPACITY;
 
-            this._updateProgressBar.hide();
-            this._updateSpinner.stop();
+            return;
+        }
+
+        this._appIcon.opacity = NORMAL_OPACITY;
+        this._nameText.opacity = NORMAL_OPACITY;
+        this._categoryText.opacity = NORMAL_OPACITY;
+
+        this._updateProgressBar.hide();
+        this._updateSpinner.stop();
+
+        if (this.appInfo.is_store_installed()) {
             this._controlsStack.visible_child_name = 'controls';
+        } else {
+            this._controlsStack.visible_child_name = 'system-app';
         }
     },
 

--- a/data/eos-app-store-app-installed-box.ui
+++ b/data/eos-app-store-app-installed-box.ui
@@ -270,6 +270,32 @@
                     <property name="name">spinner</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="box3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <child>
+                      <object class="GtkLabel" id="_systemAppLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">System App</property>
+                        <property name="margin_end">10</property>
+                        <style>
+                          <class name="app-size"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">system-app</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
Do not constrain it to the space that would usually available for the
application size, as with some translations it will not fit.

[endlessm/eos-shell#5913]
