### PR TITLE
app-list-model: do not assume info != NULL in _finish() methods

### DIFF
--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1468,7 +1468,8 @@ eos_app_list_model_install_app_finish (EosAppListModel *model,
   GTask *task = G_TASK (result);
   EosAppInfo *info = g_task_get_task_data (task);
 
-  eos_app_info_set_is_installing (info, FALSE);
+  if (info != NULL)
+    eos_app_info_set_is_installing (info, FALSE);
 
   return g_task_propagate_boolean (task, error);
 }
@@ -1542,7 +1543,8 @@ eos_app_list_model_update_app_finish (EosAppListModel *model,
   GTask *task = G_TASK (result);
   EosAppInfo *info = g_task_get_task_data (task);
 
-  eos_app_info_set_is_updating (info, FALSE);
+  if (info != NULL)
+    eos_app_info_set_is_updating (info, FALSE);
 
   return g_task_propagate_boolean (task, error);
 }
@@ -1626,7 +1628,7 @@ eos_app_list_model_uninstall_app_finish (EosAppListModel *model,
   /* If we successfully removed the application, we wait for GIO
    * to notify us before we remove the flag.
    */
-  if (!res)
+  if (!res && info != NULL)
     eos_app_info_set_is_removing (info, FALSE);
 
   return res;


### PR DESCRIPTION
EosAppListModel still uses desktop IDs for install/uninstall/update
functions. This means that the desktop ID we are given could be
non-existant, in which case we will complete the task with an error.

When the caller calls into the _finish() function though, code assumes
that the task data was set to an EosAppInfo, which will not be the case
in the situation described above.

This commit adds NULL checks before calling into EosAppInfo's API.

[endlessm/eos-shell#5904]
