### PR TITLE
app-info: resolve symlinks when checking for storage location

### DIFF
--- a/EosAppStore/lib/eos-app-info-private.h
+++ b/EosAppStore/lib/eos-app-info-private.h
@@ -26,6 +26,7 @@ struct _EosAppInfo
   char *available_version;
 
   char *info_filename;
+  GFile *application_dir;
 
   char *bundle_uri;
   char *signature_uri;


### PR DESCRIPTION
Otherwise we end up always comparing /endless/appid to
/var/endless-extra, which will always return that the application is on
primary storage.

In order to do this, we immediately resolve the symlink of the
application dir, using the same code that we were initially only using
for checking disk usage.

[endlessm/eos-shell#5977]
