### PR TITLE
appInfoBox: fix logic for remove button visibility

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -473,11 +473,13 @@ const AppInfoBox = new Lang.Class({
                 }
                 else {
                     this._installButtonLabel.set_text(BUTTON_LABEL_ADD);
-                    // like the .INSTALLED case, we only show the 'delete app'
-                    // button if the app does not have a launcher on the desktop
-                    this._removeButton.show();
                 }
                 this._installButton.show();
+
+                if (this.appInfo.is_removable()) {
+                    this._removeButton.show();
+                }
+
                 break;
 
             case EosAppStorePrivate.AppState.UNKNOWN:


### PR DESCRIPTION
Since the introduction of the installed apps page, we have changed
the logic for the remove button visibility not to take into account
whether a desktop launcher exists.
Fix a location where the logic wasn't updated, causing the remove
button not to be visible when an app had an update available.

[endlessm/eos-shell#6143]
