### PR TITLE
info-box: Request height of 38 pixels for the cancel button too

### DIFF
--- a/data/eos-app-store-app-info-box.ui
+++ b/data/eos-app-store-app-info-box.ui
@@ -183,6 +183,8 @@
                                     <property name="visible">False</property>
                                     <property name="can_focus">True</property>
                                     <property name="label" translatable="yes">Cancel</property>
+                                    <property name="height_request">38</property>
+                                    <property name="halign">start</property>
                                     <signal name="clicked" handler="_onInstallCancelButtonClicked" swapped="no"/>
                                     <style>
                                       <class name="state-button"/>


### PR DESCRIPTION
It is important to request a minimum height here now that we don't
have any vertical padding for state buttons, since the "cancel" action
does not have any icon (as "install" and "remove" do), meaning that
there's nothing there forcing a minimum height in that case, causing the
background to look too short.

Thus, use the same "height request" used in those other cases here too.

[endlessm/eos-shell#6145]
