### PR TITLE
Fix apps being minimized after launched from the app store

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -534,11 +534,6 @@ const AppInfoBox = new Lang.Class({
     _launchApp: function() {
         try {
             this.model.launch(this.appId, Gtk.get_current_event_time());
-
-            let appWindow = Gio.Application.get_default().mainWindow;
-            if (appWindow && appWindow.is_visible()) {
-                appWindow.hide();
-            }
         } catch (e) {
             log("Failed to launch app '" + this.appId + "': " + e.message);
         }

--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -47,6 +47,9 @@ const AppBaseBox = new Lang.Class({
         this._progressId = this._appInfo.connect('download-progress', Lang.bind(this, this._onDownloadProgress));
         this._stateChangedId = this._appInfo.connect('notify::state', Lang.bind(this, this._syncState));
         this._windowHideId = mainWindow.connect('hide', Lang.bind(this, this._destroyPendingDialogs));
+        mainWindow.connect('show', Lang.bind(this, function() {
+            this._syncState();
+        }));
 
         this._removeDialog = null;
 
@@ -532,9 +535,17 @@ const AppInfoBox = new Lang.Class({
     },
 
     _launchApp: function() {
+        this._installProgressSpinner.show();
+        this._installProgressSpinner.start();
+        this._installButton.hide();
+        this._installProgress.show();
+        this._installProgressLabel.set_text(_("Opening…"));
+        this._removeButton.hide();
+
         try {
             this.model.launch(this.appId, Gtk.get_current_event_time());
         } catch (e) {
+            this._syncState();
             log("Failed to launch app '" + this.appId + "': " + e.message);
         }
     },


### PR DESCRIPTION
I have added two commits related to this issue: one that will simply stop hiding the window directly after the "open" button is clicked, and another which replaces the button with a spinner and label informing the user that the app is being opened.

I understand that this doesn't fix the original issue from the source (which I believe is a race between showing the app and showing the desktop, which minimizes the app window) but it does solve it and increases the usability of the store IMO.

(see https://github.com/endlessm/eos-shell/issues/4190)
