### PR TITLE
Upate a link app's icon when its favicon has been retrieved

### DIFF
--- a/EosAppStore/appListModel.js
+++ b/EosAppStore/appListModel.js
@@ -213,6 +213,10 @@ const AppListModel = new Lang.Class({
 
     createLink: function(filename) {
         return this._model.create_from_filename(filename);
+    },
+
+    updateAppIcon: function(filename) {
+        return this._model.update_app_icon_from_filename(filename);
     }
 });
 Signals.addSignalMethods(AppListModel.prototype);

--- a/EosAppStore/lib/eos-app-list-model.c
+++ b/EosAppStore/lib/eos-app-list-model.c
@@ -1749,3 +1749,39 @@ eos_app_list_model_create_from_filename (EosAppListModel *model,
 
   return info;
 }
+
+gboolean
+eos_app_list_model_update_app_icon_from_filename (EosAppListModel *self,
+                                                  const char *filename,
+                                                  GError **error_out)
+{
+  GError *error = NULL;
+  EosAppInfo *info;
+  GDesktopAppInfo *desktop_info;
+  const char *desktop_id;
+
+  desktop_info = g_desktop_app_info_new_from_filename (filename);
+  if (!desktop_info)
+    return FALSE;
+
+  desktop_id = g_app_info_get_id (G_APP_INFO (desktop_info));
+
+  g_dbus_connection_call_sync (self->session_bus,
+                               "org.gnome.Shell",
+                               "/org/gnome/Shell",
+                               "org.gnome.Shell.AppStore", "UpdateApplication",
+                               g_variant_new ("(s)", desktop_id),
+                               NULL,
+                               G_DBUS_CALL_FLAGS_NONE,
+                               -1,
+                               NULL,
+                               &error);
+
+  if (error != NULL)
+    {
+      g_propagate_error (error_out, error);
+      return FALSE;
+    }
+
+  return TRUE;
+}

--- a/EosAppStore/lib/eos-app-list-model.h
+++ b/EosAppStore/lib/eos-app-list-model.h
@@ -80,6 +80,10 @@ gboolean eos_app_list_model_update_app_finish       (EosAppListModel *model,
                                                      GAsyncResult *result,
                                                      GError **error);
 
+gboolean eos_app_list_model_update_app_icon_from_filename (EosAppListModel *self,
+                                                           const char *filename,
+                                                           GError **error_out);
+
 G_END_DECLS
 
 #endif /* __EOS_APP_LIST_MODEL_H__ */

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -158,6 +158,7 @@ const NewSiteHelper = new Lang.Class({
             if (this._savedKeyfile) {
                 this._saveFavicon();
                 this._updateFavicon();
+                this._model.updateAppIcon(this._savedKeyfilePath);
             }
         }
     },


### PR DESCRIPTION
These changes call a new DBus method that is used to inform the desktop that something about the application (in this case the icon) has changed and its icon should be updated/reloaded.

[endlessm/eos-shell#4920]
