### PR TITLE
appStoreWindow: fix clicking on cells from search results

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -471,6 +471,22 @@ const AppSearchFrame = new Lang.Class({
         this.parent(category);
 
         this._mainWindow.search_entry.connect('search-changed', Lang.bind(this, this._onSearchChanged));
+        this._searchTerms = null;
+    },
+
+    _onPageChanged: function() {
+        this.parent();
+
+        if (this._lastPageId != CONTENT_PAGE) {
+            // save search terms to go back to later
+            this._searchTerms = this._mainWindow.searchTerms;
+            this._mainWindow.clearSearchState();
+        }
+        else if (this._searchTerms) {
+            // resume search
+            this._mainWindow.searchTerms = this._searchTerms;
+            this._searchTerms = null;
+        }
     },
 
     _onSearchChanged: function() {

--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -318,10 +318,7 @@ const AppStoreWindow = new Lang.Class({
         // still searching we cancel the search
         let pageId = this._pageManager.visible_child_name;
         if (pageId != 'search' && this.search_bar.search_mode_enabled) {
-            // We unset this here to ensure that _onSearchEnabledChanged
-            // does not switch page again
-            this._searchPrevPage = null;
-            this.search_bar.search_mode_enabled = false;
+            this.clearSearchState();
         }
 
         this.clearHeaderState();
@@ -336,6 +333,13 @@ const AppStoreWindow = new Lang.Class({
         let [width, height, sidebarWidth] = this._getSize();
 
         return width;
+    },
+
+    clearSearchState: function(switchBack) {
+        // We unset this here to ensure that _onSearchEnabledChanged
+        // does not switch page again
+        this._searchPrevPage = null;
+        this.search_bar.search_mode_enabled = false;
     },
 
     clearHeaderState: function() {
@@ -389,6 +393,11 @@ const AppStoreWindow = new Lang.Class({
 
     get searchTerms() {
         return this.search_entry.get_text();
+    },
+
+    set searchTerms(v) {
+        this.search_entry.set_text(v);
+        this.search_bar.search_mode_enabled = true;
     },
 
     populate: function() {


### PR DESCRIPTION
In that case, we want to clear the search entry, and make the back
button go back to the search results.

[endlessm/eos-shell#6359]
