### PR TITLE
Do not filter search results

### DIFF
--- a/EosAppStore/appFrame.js
+++ b/EosAppStore/appFrame.js
@@ -493,6 +493,11 @@ const AppSearchFrame = new Lang.Class({
         this._model.searchTerms(this._mainWindow.searchTerms);
     },
 
+    _prepareAppInfos: function(appInfos) {
+        // No filtering applied to searches
+        return appInfos;
+    },
+
     getTitle: function() {
         return _("Search results");
     },


### PR DESCRIPTION
The search results do not need additional filtering done. Since
AppSearchFrame inherits from AppCategoryFrame, the _prepareAppInfos()
method in the parent class must be overridden.

[endlessm/eos-shell#6371]
