### PR TITLE
weblinkFrame: Fix AppStore window expanding on big website titles

### DIFF
--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -303,6 +303,7 @@ const NewSiteBox = new Lang.Class({
 
         this._urlLabel = new Gtk.Label();
         this._urlLabel.get_style_context().add_class('url-label');
+        this._urlLabel.set_ellipsize(Pango.EllipsizeMode.END);
         this._urlLabel.set_alignment(0, 0);
         this._urlLabel.show();
 


### PR DESCRIPTION
This patch sets the ellipsize mode on the label that shows an added
website title, so it does not make the AppStore window expand when the
title is too long.

[endlessm/eos-shell#6367]
