### PR TITLE
AppInfoBox: Reset the install button as sensitive

### DIFF
--- a/EosAppStore/appInfoBox.js
+++ b/EosAppStore/appInfoBox.js
@@ -417,6 +417,9 @@ const AppInfoBox = new Lang.Class({
         this._installButton.hide();
         this._removeButton.hide();
 
+        // reset install button as sensitive
+        this._installButton.set_sensitive(true);
+
         const BUTTON_LABEL_INSTALL = _("Install app");
         const BUTTON_LABEL_UPDATE = _("Update app");
         const BUTTON_LABEL_LAUNCH = _("Open app");


### PR DESCRIPTION
Otherwise when changing the button's function (add to
desktop/update/etc.) it would sometimes leave the button insensitive
when it shouldn't.

https://phabricator.endlessm.com/T4628
