### PR TITLE
fillDesktop: fix app activation

### DIFF
--- a/EosAppStore/fillDesktop.js
+++ b/EosAppStore/fillDesktop.js
@@ -55,7 +55,7 @@ const FillDesktop = new Lang.Class({
             return 1;
         }
 
-        return 0;
+        return -1;
     },
 
     vfunc_activate: function() {


### PR DESCRIPTION
From the documentation of GApplication, returning 0 means that the
process will exit. We should return -1 to make GApplication call
activate() for us.

https://phabricator.endlessm.com/T10863
