### PR TITLE
Remove all the app pages

### DIFF
--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -408,7 +408,13 @@ const AppStoreWindow = new Lang.Class({
         this.side_pane_box.stack = this._pageManager;
         this.content_box.add(this._pageManager);
 
-        this._pageManager.registerProvider(new AppFrame.AppPageProvider());
+        // Sabotage!
+        //
+        // As part of our transition from eos-app-store to GNOME Software, we no
+        // longer register the AppPageProvider here. The app store will be used
+        // only to handle weblinks and desktop folders until it is retired.
+        //
+        //this._pageManager.registerProvider(new AppFrame.AppPageProvider());
         this._pageManager.registerProvider(new WeblinkFrame.WeblinkFrame());
         this._pageManager.registerProvider(new FolderFrame.FolderFrame());
     },

--- a/EosAppStore/categories.js
+++ b/EosAppStore/categories.js
@@ -2,7 +2,9 @@
 const EosAppStorePrivate = imports.gi.EosAppStorePrivate;
 const Lang = imports.lang;
 
-const DEFAULT_APP_CATEGORY = 'education';
+// Originally 'education'. Changed to 'web' to default to the weblink page, as
+// the app store no longer supports viewing or installing apps.
+const DEFAULT_APP_CATEGORY = 'web';
 
 function get_app_categories() {
     return [

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -534,6 +534,15 @@ const WeblinkListBoxRow = new Lang.Class({
         this._nameLabel.set_text(this._info.get_title());
         this._descriptionLabel.set_text(this._info.get_description());
 
+        this._model.connect('loading-changed', Lang.bind(this, this._onModelLoadingChanged));
+        this._onModelLoadingChanged();
+    },
+
+    _onModelLoadingChanged: function(model) {
+        if (this._model.loading) {
+            return;
+        }
+
         let installedSensitive = (!this._model.hasLauncher(this._info.get_desktop_id()));
         this._setSensitiveState(installedSensitive);
         this._mainBox.show();


### PR DESCRIPTION
As part of our transition from eos-app-store to GNOME Software, we no
longer allow installing apps from the app store. It will be used only to
handle weblinks and desktop folders, and only as a temporary transition
measure.

Accordingly, we need to modify the WeblinkFrame to wait for the
appListModel to finish loading before we use it, since we can't rely on
the AppPageProvider ensuring this anymore.

We also need to modify the default page.

https://phabricator.endlessm.com/T11224
