### PR TITLE
weblinkFrame: Properly handle failed page loads

### DIFF
--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -484,7 +484,9 @@ const NewSiteBox = new Lang.Class({
     _onWebsiteLoaded: function() {
         // We need to mark the URL as FOUND whenever a load finishes, so that
         // we make sure we don't end up waiting forever when there's no title.
-        this._setState(NewSiteBoxState.FOUND);
+        if (this._state != NewSiteBoxState.ERROR) {
+            this._setState(NewSiteBoxState.FOUND);
+        }
     },
 
     _onSiteAlertEnterEvent: function() {


### PR DESCRIPTION
When a page load fails, WebKit emits load-failed and then transitions
to the LOAD_FINISHED state. Here we are assuming that LOAD_FINISHED
indicates a successful load, which is not correct, and causes us to
inappropriately transition away from the error state immediately after
every error. It's also causing a JS error.

https://phabricator.endlessm.com/T11604
