### PR TITLE
weblink: store validated url to desktop launcher

### DIFF
--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -122,10 +122,10 @@ const NewSiteHelper = new Lang.Class({
         if (url.indexOf('http://') != 0 && url.indexOf('https://') != 0 &&
             url.indexOf('ftp://')  != 0 && url.indexOf('file://')  != 0) {
             // if it does not start with a valid prefix, prepend http://
-            url = 'http://' + url;
+            this._url = 'http://' + url;
         }
 
-        this._webView.load_uri(url);
+        this._webView.load_uri(this._url);
     },
 
     _saveFavicon: function() {


### PR DESCRIPTION
We already validated the url and added a valid prefix ('http://')
when not there. This was only used for the webView but not when
storing the url in the desktop file. Therefore gvfs-open tried
to open the url as a local file and failed.

https://phabricator.endlessm.com/T18051