### PR TITLE
T24818: Define exported symbols with 'var' instead of 'const'

### DIFF
--- a/EosAppStore/appStore.js
+++ b/EosAppStore/appStore.js
@@ -30,7 +30,7 @@ const CLEAR_TIMEOUT = 300;
 // many seconds
 const QUIT_TIMEOUT = 15;
 
-const AppStore = new Lang.Class({
+var AppStore = new Lang.Class({
     Name: 'AppStore',
     Extends: Gtk.Application,
 

--- a/EosAppStore/appStoreDBusService.js
+++ b/EosAppStore/appStoreDBusService.js
@@ -24,7 +24,7 @@ const AppStoreDBusIface = '<node><interface name="com.endlessm.AppStore">' +
   '<property name="Visible" type="b" access="read"/>' +
 '</interface></node>';
 
-const AppStoreDBusService = new Lang.Class({
+var AppStoreDBusService = new Lang.Class({
     Name: 'AppStoreDBusService',
 
     _init: function(app) {

--- a/EosAppStore/appStoreLauncher.js
+++ b/EosAppStore/appStoreLauncher.js
@@ -21,7 +21,7 @@ const AppStoreIface = '<node><interface name="com.endlessm.AppStore">' +
 
 const AppStoreProxy = Gio.DBusProxy.makeProxyWrapper(AppStoreIface);
 
-const AppStoreLauncher = new Lang.Class({
+var AppStoreLauncher = new Lang.Class({
     Name: 'AppStoreLauncher',
 
     _init: function() {

--- a/EosAppStore/appStorePages.js
+++ b/EosAppStore/appStorePages.js
@@ -3,7 +3,7 @@ const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Signals = imports.signals;
 
-const AppStorePageManager = new Lang.Class({
+var AppStorePageManager = new Lang.Class({
     Name: 'AppStorePageManager',
     Extends: Gtk.Stack,
 
@@ -54,7 +54,7 @@ const AppStorePageManager = new Lang.Class({
     }
 });
 
-const AppStorePageProvider = new Lang.Interface({
+var AppStorePageProvider = new Lang.Interface({
     Name: 'AppStorePageProvider',
 
     createPage: Lang.Interface.UNIMPLEMENTED,

--- a/EosAppStore/appStoreWindow.js
+++ b/EosAppStore/appStoreWindow.js
@@ -17,7 +17,7 @@ const WMInspect = imports.wmInspect;
 
 const SIDE_COMPONENT_ROLE = 'eos-side-component';
 
-const AppStoreSizes = {
+var AppStoreSizes = {
     // Note: must be listed in order of increasing screenWidth.
     // Window widths are chosen by design to match a specific
     // number of columns of tiles on the application grid.
@@ -45,7 +45,7 @@ const AppStoreSizes = {
             sidebarWidth: 215 }
 };
 
-const AppStoreWindow = new Lang.Class({
+var AppStoreWindow = new Lang.Class({
     Name: 'AppStoreWindow',
     Extends: Gtk.ApplicationWindow,
     Signals: {

--- a/EosAppStore/categories.js
+++ b/EosAppStore/categories.js
@@ -2,7 +2,7 @@
 const EosAppStorePrivate = imports.gi.EosAppStorePrivate;
 const Lang = imports.lang;
 
-const DEFAULT_APP_CATEGORY = 'web';
+var DEFAULT_APP_CATEGORY = 'web';
 
 function get_link_categories() {
     return [

--- a/EosAppStore/categoryButton.js
+++ b/EosAppStore/categoryButton.js
@@ -5,7 +5,7 @@ const Gtk = imports.gi.Gtk;
 
 const Lang = imports.lang;
 
-const CategoryButton = new Lang.Class({
+var CategoryButton = new Lang.Class({
     Name: 'CategoryButton',
     Extends: Gtk.RadioButton,
     Properties: { 'category': GObject.ParamSpec.string('category',

--- a/EosAppStore/separator.js
+++ b/EosAppStore/separator.js
@@ -5,7 +5,7 @@ const Lang = imports.lang;
 const EDGE_WIDTH = 55;
 const SHADOW_HEIGHT = 11;
 
-const FrameSeparator = new Lang.Class({
+var FrameSeparator = new Lang.Class({
     Name: 'FrameSeparator',
     Extends: Gtk.Box,
 

--- a/EosAppStore/shellAppStore.js
+++ b/EosAppStore/shellAppStore.js
@@ -31,7 +31,7 @@ const SHELL_APP_STORE_IFACE = 'org.gnome.Shell.AppStore';
 
 const ShellAppStoreProxy = Gio.DBusProxy.makeProxyWrapper(AppStoreIface);
 
-const ShellAppStore = new Lang.Class({
+var ShellAppStore = new Lang.Class({
     Name: 'ShellAppStore',
 
     _init: function() {

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -94,7 +94,7 @@ function createWeblink(url, title, icon) {
     return [availablePath, desktop];
 };
 
-const NewSiteHelper = new Lang.Class({
+var NewSiteHelper = new Lang.Class({
     Name: 'NewSiteHelper',
 
     _init: function(url) {
@@ -228,7 +228,7 @@ const NewSiteBoxState = {
     INSTALLED: 5
 };
 
-const NewSiteBox = new Lang.Class({
+var NewSiteBox = new Lang.Class({
     Name: 'NewSiteBox',
     Extends: Gtk.Bin,
 
@@ -509,7 +509,7 @@ const NewSiteBox = new Lang.Class({
 });
 Builder.bindTemplateChildren(NewSiteBox.prototype);
 
-const WeblinkListBoxRow = new Lang.Class({
+var WeblinkListBoxRow = new Lang.Class({
     Name: 'WeblinkListBoxRow',
     Extends: Gtk.EventBox,
 
@@ -587,7 +587,7 @@ const WeblinkListBoxRow = new Lang.Class({
 });
 Builder.bindTemplateChildren(WeblinkListBoxRow.prototype);
 
-const WeblinkListBox = new Lang.Class({
+var WeblinkListBox = new Lang.Class({
     Name: 'WeblinkListBox',
     Extends: Gtk.ListBox,
 
@@ -597,7 +597,7 @@ const WeblinkListBox = new Lang.Class({
     }
 });
 
-const WeblinkListBoxRowSeparator = new Lang.Class({
+var WeblinkListBoxRowSeparator = new Lang.Class({
     Name: 'WeblinkListBoxRowSeparator',
     Extends: Gtk.Frame,
 
@@ -607,7 +607,7 @@ const WeblinkListBoxRowSeparator = new Lang.Class({
     }
 });
 
-const WeblinkFrame = new Lang.Class({
+var WeblinkFrame = new Lang.Class({
     Name: 'WeblinkFrame',
     Extends: Gtk.Frame,
     Implements: [AppStorePages.AppStorePageProvider],

--- a/EosAppStore/weblinkFrame.js
+++ b/EosAppStore/weblinkFrame.js
@@ -152,7 +152,7 @@ var NewSiteHelper = new Lang.Class({
             this._favicon = favicon;
             this.emit('favicon-loaded');
 
-            // if we saved the desktop file already, update it 
+            // if we saved the desktop file already, update it
             // with the new icon
             if (this._savedKeyfile) {
                 this._saveFavicon();

--- a/EosAppStore/wmInspect.js
+++ b/EosAppStore/wmInspect.js
@@ -2,7 +2,7 @@ const Lang = imports.lang;
 const Signals = imports.signals;
 const Wnck = imports.gi.Wnck;
 
-const WMInspect = new Lang.Class({
+var WMInspect = new Lang.Class({
     Name: 'WMInspect',
 
     _init: function() {


### PR DESCRIPTION
Any symbols (including class properties) that should be visible
outside the module it's defined in need to be defined as global.
For now gjs still allows the access for 'const', but get rid of
the warnings spill now by changing it.

https://phabricator.endlessm.com/T24818